### PR TITLE
add radix to toInt

### DIFF
--- a/lib/filter.js
+++ b/lib/filter.js
@@ -60,8 +60,9 @@ Filter.prototype.toFloat = function() {
     return this.str;
 }
 
-Filter.prototype.toInt = function() {
-    this.modify(parseInt(this.str));
+Filter.prototype.toInt = function(radix) {
+    radix = radix || 10;
+    this.modify(parseInt(this.str, radix));
     return this.str;
 }
 


### PR DESCRIPTION
parseInt will return interpret "015" as octal and return 13 by default. 

Base 10 seems like a decent assumption there imo.

parseInt('015') = 13 // the f***?
parseInt('015', 10) = 15 //expected imo
