### PR TITLE
Link to express-validator in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ var str = sanitize('&lt;a&gt;').entityDecode();      //'<a>'
 
 Often it's more desirable to check or automatically sanitize parameters by name (rather than the actual string). See [this gist](https://gist.github.com/752126) for instructions on binding the library to the `request` prototype.
 
+If you are using the [express.js framework](https://github.com/visionmedia/express) you can use the [express-validator middleware](https://github.com/ctavan/express-validator) to seamlessly integrate node-validator.
+
 Example `http://localhost:8080/?zip=12345&foo=1&textarea=large_string`
 
 ```javascript


### PR DESCRIPTION
Hey Chris,

I've wrapped your [gist](https://gist.github.com/752126) into an npm module to ease up integration with express.js. There was already a similar approach called [express-validate](https://github.com/Dream-Web/express-validate) but I prefer the approach you chose in your gist. Would be nice if you would accept the link in the readme. I've tried to give as much credit as possible, if you want me to change anything just let me know.

Cheers, Christoph
