### PR TITLE
Bug in url-validation

### DIFF
--- a/test/validator.test.js
+++ b/test/validator.test.js
@@ -78,7 +78,8 @@ module.exports = {
             'http://www.foobar.com/~foobar',
             'http://user:pass@www.foobar.com/',
             'http://127.0.0.1/',
-            'http://255.255.255.255/'
+            'http://255.255.255.255/',
+            'http://duckduckgo.com/?q=%2F'
         ];
         try {
             valid.forEach(function(url) {


### PR DESCRIPTION
The url validation does not allow parts in the querystring like %3F, which it should, since this is the std output for instance duckduckgo and google use. Since there only was one monolithic regex i assumed it was generated, and only added a test for this case, and did not edit the regex.
