### PR TITLE
Fix for non string escapes of regex

### DIFF
--- a/lib/xss.js
+++ b/lib/xss.js
@@ -111,16 +111,16 @@ exports.clean = function(str, is_image) {
         var original = str;
 
         if (str.match(/<a/i)) {
-            str = str.replace(/<a\\s+([^>]*?)(>|$)/gi, function(m, attributes, end_tag) {
+            str = str.replace(/<a\s+([^>]*?)(>|$)/gi, function(m, attributes, end_tag) {
                 attributes = filter_attributes(attributes.replace('<','').replace('>',''));
-                return m.replace(attributes, attributes.replace(/href=.*?(alert\(|alert&\#40;|javascript\:|charset\=|window\.|document\.|\.cookie|<script|<xss|base64\\s*,)/gi, ''));
+                return m.replace(attributes, attributes.replace(/href=.*?(alert\(|alert&\#40;|javascript\:|charset\=|window\.|document\.|\.cookie|<script|<xss|base64\s*,)/gi, ''));
             });
         }
 
         if (str.match(/<img/i)) {
-            str = str.replace(/<img\\s+([^>]*?)(\\s?\/?>|$)/gi, function(m, attributes, end_tag) {
+            str = str.replace(/<img\s+([^>]*?)(\s?\/?>|$)/gi, function(m, attributes, end_tag) {
                 attributes = filter_attributes(attributes.replace('<','').replace('>',''));
-                return m.replace(attributes, attributes.replace(/src=.*?(alert\(|alert&\#40;|javascript\:|charset\=|window\.|document\.|\.cookie|<script|<xss|base64\\s*,)/gi, ''));
+                return m.replace(attributes, attributes.replace(/src=.*?(alert\(|alert&\#40;|javascript\:|charset\=|window\.|document\.|\.cookie|<script|<xss|base64\s*,)/gi, ''));
             });
         }
 
@@ -157,7 +157,7 @@ exports.clean = function(str, is_image) {
     //code, it simply converts the parenthesis to entities rendering the code un-executable.
     //For example:    eval('some code')
     //Becomes:        eval&#40;'some code'&#41;
-    str = str.replace(/(alert|cmd|passthru|eval|exec|expression|system|fopen|fsockopen|file|file_get_contents|readfile|unlink)(\\s*)\((.*?)\)/gi, '$1$2&#40;$3&#41;');
+    str = str.replace(/(alert|cmd|passthru|eval|exec|expression|system|fopen|fsockopen|file|file_get_contents|readfile|unlink)(\s*)\((.*?)\)/gi, '$1$2&#40;$3&#41;');
 
     //This adds a bit of extra precaution in case something got through the above filters
     for (var i in never_allowed_str) {
@@ -195,7 +195,7 @@ function convert_attribute(str) {
 function filter_attributes(str) {
     out = '';
 
-    str.replace(/\\s*[a-z\-]+\\s*=\\s*(?:\042|\047)(?:[^\\1]*?)\\1/gi, function(m) {
+    str.replace(/\s*[a-z\-]+\s*=\s*(?:\042|\047)(?:[^\\1]*?)\\1/gi, function(m) {
         $out += m.replace(/\/\*.*?\*\//g, '');
     });
 


### PR DESCRIPTION
There is a bug in the xss check where the regex is getting escaped even if its not a string, this results in a bug where the anchor tags are not filtered in xss.js
