### PR TITLE
_errors array getting reassigned on each check

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,13 @@ Validator.prototype.error = function (msg) {
 Validator.prototype.getErrors = function () {
     return this._errors;
 }
+
+var validator = new Validator();
+
+validator.check('abc').isEmail();
+validator.check('hello').len(10,30);
+
+var errors = validator.getErrors(); // ['Invalid email', 'String is too small']
 ```
 
 ## Contributors

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -9,7 +9,7 @@ Validator.prototype.check = function(str, fail_msg) {
       this.str += '';
     }
     this.msg = fail_msg;
-    this._errors = [];
+    this._errors = this._errors || [];
     return this;
 }
 


### PR DESCRIPTION
Hey,

I want to do collect the errors instead of throwing them. Found an error that caused the array to get reset so it only displayed the last error. Here is a pull request to fix it. 

Great job on this library, I'm integrating into my Couchdb ODM (http://github.com/garrensmith/LazyBoy) makes my life easier.

Cheers
Garren
