### PR TITLE
get back the param used in express-validator

### DIFF
--- a/lib/validator.js
+++ b/lib/validator.js
@@ -8,7 +8,7 @@ Validator.prototype.error = function (msg) {
     return this;
 };
 
-Validator.prototype.check = function(str, fail_msg) {
+Validator.prototype.check = function(str, fail_msg, param) {
     this.str = (str == null || (isNaN(str) && str.length == undefined)) ? '' : str;
     // Convert numbers to strings but keep arrays/objects
     if (typeof this.str == 'number') {
@@ -16,6 +16,7 @@ Validator.prototype.check = function(str, fail_msg) {
     }
     this.msg = fail_msg;
     this._errors = this._errors || [];
+    this.param = param;
     return this;
 }
 
@@ -26,7 +27,7 @@ for (var key in validators) {
                 var args = Array.prototype.slice.call(arguments);
                 args.unshift(this.str);
                 if(!validators[key].apply(this, args)) {
-                    return this.error(this.msg || defaultError[key]);
+                    return this.error(this.msg || defaultError[key], this.param);
                 }
                 return this;
             };


### PR DESCRIPTION
This commit is meant to work in conjunction with another pull request on express-validator that I'll make if you accept this one.
https://github.com/orfaust/express-validator/commit/dedfa03e1f41c558c64d2d786e67abaaa71ed4f5

These changes don't break the normal use of node-validator (at least they should not :)
The purpose is to let you get back the param used to check a field and make a hash of errors to display in a template:

<pre>
var errors = {};
req.onValidationError(function(msg, param)
{
    var error = {};
    errors[param] = msg;
    return this;
});

req.check('email', 'Email not valid').isEmail();
req.check('password', 'Password is empty').notEmpty();

if(errors)
{
    console.log(errors);
    return;
}
</pre>

output in case of errors:

<pre>
{ email: 'Email not valid', password, 'Password is empty' }
</pre>

Then you'd use it in a template like:

<pre>
- if(errors.email)
    input.error(type="text", name="email", value="#{values.email}")
    span.error= errors.email
- else
    input.(type="text", name="email")
</pre>
