### PR TITLE
Fixed semicolon in wrong place in entities like &#39; (apostrophe)

### DIFF
--- a/lib/xss.js
+++ b/lib/xss.js
@@ -53,7 +53,7 @@ exports.clean = function(str, is_image) {
     str = str.replace(/\&([a-z\_0-9]+)\=([a-z\_0-9]+)/i, xss_hash() + '$1=$2');
 
     //Validate UTF16 two byte encoding (x00) - just as above, adds a semicolon if missing.
-    str = str.replace(/(&\#x?)([0-9A-F]+);?/i, '$1;$2');
+    str = str.replace(/(&\#x?)([0-9A-F]+);?/i, '$1$2;');
 
     //Un-protect query string variables
     str = str.replace(xss_hash(), '&');


### PR DESCRIPTION
Fixed semicolon in wrong place when ensuring semicolon in an entity like &#39; corrects https://github.com/chriso/node-validator/issues/77
