### PR TITLE
Fix for #83

### DIFF
--- a/lib/entities.js
+++ b/lib/entities.js
@@ -3,7 +3,7 @@ var entities = {
     '&iexcl;': '\u00a1',
     '&cent;': '\u00a2',
     '&pound;': '\u00a3',
-    '&curren;': '\u20ac',
+    '&euro;': '\u20ac',
     '&yen;': '\u00a5',
     '&brvbar;': '\u0160',
     '&sect;': '\u00a7',

--- a/test/filter.test.js
+++ b/test/filter.test.js
@@ -115,7 +115,7 @@ module.exports = {
         assert.equal('&', Filter.sanitize('&amp;').entityDecode());
         assert.equal('&&', Filter.sanitize('&amp;&amp;').entityDecode());
         assert.equal('""', Filter.sanitize('&quot;&quot;').entityDecode());
-        assert.equal('€', Filter.sanitize('&curren;').entityDecode());
+        assert.equal('€', Filter.sanitize('&euro;').entityDecode());
         assert.equal("'", Filter.sanitize("&#39;").entityDecode());
         assert.equal("'", Filter.sanitize("&apos;").entityDecode());
     },
@@ -125,7 +125,7 @@ module.exports = {
         assert.equal('&amp;&amp;', Filter.sanitize('&&').entityEncode());
         assert.equal('&#39;', Filter.sanitize("'").entityEncode());
         assert.equal('&quot;&quot;', Filter.sanitize('""').entityEncode());
-        assert.equal('&curren;', Filter.sanitize('€').entityEncode());
+        assert.equal('&euro;', Filter.sanitize('€').entityEncode());
     },
 
     'test #xss()': function () {


### PR DESCRIPTION
Changed the entity of the € sign from `&curren;` to `&euro;`. The Unicode
character number (0x20AC) was right.
See http://www.fileformat.info/info/unicode/char/20ac/index.htm
and http://www.mail-archive.com/use-revolution@lists.runrev.com/msg109291.html
