### PR TITLE
Fix isUUID() bug: Extra characters before UUID are accepted as valid.

### DIFF
--- a/lib/validators.js
+++ b/lib/validators.js
@@ -111,11 +111,11 @@ var validators = module.exports = {
     isUUID: function(str, version) {
         var pattern;
         if (version == 3 || version == 'v3') {
-            pattern = /[0-9A-F]{8}-[0-9A-F]{4}-3[0-9A-F]{3}-[0-9A-F]{4}-[0-9A-F]{12}$/i;
+            pattern = /^[0-9A-F]{8}-[0-9A-F]{4}-3[0-9A-F]{3}-[0-9A-F]{4}-[0-9A-F]{12}$/i;
         } else if (version == 4 || version == 'v4') {
-            pattern = /[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i;
+            pattern = /^[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i;
         } else {
-            pattern = /[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}$/i;
+            pattern = /^[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}$/i;
         }
         return str.match(pattern);
     },

--- a/test/validator.test.js
+++ b/test/validator.test.js
@@ -400,10 +400,24 @@ module.exports = {
         assert.ok(Validator.check('A987FBC9-4BED-3078-CF07-9141BA07C9F3').isUUID(3));
         assert.ok(Validator.check('A987FBC9-4BED-4078-8F07-9141BA07C9F3').isUUID(4));
 
-        try {
-            Validator.check('A987FBC9-4BED-3078-CF07-9141BA07C9F3').isUUID(4);
-            assert.ok(false, 'isUUID failed');
-        } catch (e) {}
+        var badUuids = [
+            "",
+            null,
+            "xxxA987FBC9-4BED-3078-CF07-9141BA07C9F3",
+            "A987FBC9-4BED-3078-CF07-9141BA07C9F3xxx",
+            "A987FBC94BED3078CF079141BA07C9F3",
+            "934859",
+            "987FBC9-4BED-3078-CF07A-9141BA07C9F3",
+            "AAAAAAAA-1111-1111-AAAG-111111111111"
+        ]
+
+        badUuids.forEach(function (item) {
+            assert.throws(function() { Validator.check(item).isUUID() },  /not a uuid/i);
+            assert.throws(function() { Validator.check(item).isUUID(1) }, /not a uuid/i);
+            assert.throws(function() { Validator.check(item).isUUID(2) }, /not a uuid/i);
+            assert.throws(function() { Validator.check(item).isUUID(3) }, /not a uuid/i);
+            assert.throws(function() { Validator.check(item).isUUID(4) }, /not a uuid/i);
+        });
 
         try {
             Validator.check('A987FBC9-4BED-4078-0F07-9141BA07C9F3').isUUID(4);


### PR DESCRIPTION
Hi there,

The regex patterns for UUIDs needed a 'start of line' "^" matcher at the beginning of the patterns.

Whilst testing that, I threw in a few extra tests for other possible edge cases whilst I was at, it in order to better proof against future UUID regressions.

Scott
