### PR TITLE
adding validator#throws(boolean) + bug fix on #check(object)

### DIFF
--- a/lib/validator.js
+++ b/lib/validator.js
@@ -23,7 +23,7 @@ Validator.prototype.throws = function(isThrows){
 }
 
 Validator.prototype.check = function(str, fail_msg) {
-    this.str = (str == null || (isNaN(str) && str.length == undefined)) ? '' : str;
+    this.str = (str == null || (isNaN(str) && str.length == undefined && 'object' != typeof str)) ? '' : str;
     // Convert numbers to strings but keep arrays/objects
     if (typeof this.str == 'number') {
         this.str += '';

--- a/test/validator.test.js
+++ b/test/validator.test.js
@@ -640,5 +640,13 @@ module.exports = {
             c.max(0);
         });
         assert.equal(c._errors.length, 3);
+    },
+    'test #check keeps arrays': function(){ 
+        Validator.check([1,2,3], " a test array");
+        assert.deepEqual(Validator.str, [1,2,3]);
+    },
+    'test #check keeps objects': function(){ 
+        Validator.check({test:'object'}, " a test object");
+        assert.deepEqual(Validator.str, {test:'object'});
     }
 }


### PR DESCRIPTION
consider the following two cases, expressed in the tests bellow

```

    'test #throws(false) stops throwing': function() { 
        var c = (new node_validator.Validator()).check(1).throws(false);
        assert.doesNotThrow( function() { 
            c.min(2);
            c.max(0);
        });
        assert.equal(c._errors.length, 2);
    },
    'test #throws(true) brings back throwing' : function() { 
        var c = (new node_validator.Validator()).check(1);

        c.throws(false);
        assert.doesNotThrow( function() { 
            c.min(2);
            c.max(0);
        });
        assert.equal(c._errors.length, 2);

        c.throws(true);
        assert.throws( function() { 
            c.min(2);
            c.max(0);
        });
        assert.equal(c._errors.length, 3);
    }

```
