### PR TITLE
Add checking types (has object match function) to validators

### DIFF
--- a/lib/validators.js
+++ b/lib/validators.js
@@ -25,9 +25,11 @@ function toDate(date) {
 
 var validators = module.exports = {
     isEmail: function(str) {
+        if(!str.match) return false;
         return str.match(/^(?:[\w\!\#\$\%\&\'\*\+\-\/\=\?\^\`\{\|\}\~]+\.)*[\w\!\#\$\%\&\'\*\+\-\/\=\?\^\`\{\|\}\~]+@(?:(?:(?:[a-zA-Z0-9](?:[a-zA-Z0-9\-](?!\.)){0,61}[a-zA-Z0-9]?\.)+[a-zA-Z0-9](?:[a-zA-Z0-9\-](?!$)){0,61}[a-zA-Z0-9]?)|(?:\[(?:(?:[01]?\d{1,2}|2[0-4]\d|25[0-5])\.){3}(?:[01]?\d{1,2}|2[0-4]\d|25[0-5])\]))$/);
     },
     isUrl: function(str) {
+        if(!str.match) return false;
         return str.match(/^(?:(?:ht|f)tp(?:s?)\:\/\/|~\/|\/)?(?:\w+:\w+@)?(localhost|(?:(?:[-\w\d{1-3}]+\.)+(?:com|org|net|gov|mil|biz|info|mobi|name|aero|jobs|edu|co\.uk|ac\.uk|it|fr|tv|museum|asia|local|travel|[a-z]{2}))|((\b25[0-5]\b|\b[2][0-4][0-9]\b|\b[0-1]?[0-9]?[0-9]\b)(\.(\b25[0-5]\b|\b[2][0-4][0-9]\b|\b[0-1]?[0-9]?[0-9]\b)){3}))(?::[\d]{1,5})?(?:(?:(?:\/(?:[-\w~!$+|.,="'\(\)_\*]|%[a-f\d]{2})+)+|\/)+|\?|#)?(?:(?:\?(?:[-\w~!$+|.,*:]|%[a-f\d{2}])+=?(?:[-\w~!$+|.,*:=]|%[a-f\d]{2})*)(?:&(?:[-\w~!$+|.,*:]|%[a-f\d{2}])+=?(?:[-\w~!$+|.,*:=]|%[a-f\d]{2})*)*)*(?:#(?:[-\w~!$ |\/.,*:;=]|%[a-f\d]{2})*)?$/i) || str.length > 2083;
     },
     isIP: function(str) {
@@ -40,21 +42,27 @@ var validators = module.exports = {
         return net.isIP(str) !== 0;
     },
     isIPManual: function(str) {
+        if(!str.match) return false;
         return str.match(/^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/);
     },
     isAlpha: function(str) {
+        if(!str.match) return false;
         return str.match(/^[a-zA-Z]+$/);
     },
     isAlphanumeric: function(str) {
+        if(!str.match) return false;
         return str.match(/^[a-zA-Z0-9]+$/);
     },
     isNumeric: function(str) {
+        if(!str.match) return false;
         return str.match(/^-?[0-9]+$/);
     },
     isLowercase: function(str) {
+        if(!str.match) return false;
         return str.match(/^[a-z0-9]+$/);
     },
     isUppercase: function(str) {
+        if(!str.match) return false;
         return str.match(/^[A-Z0-9]+$/);
     },
     isInt: function(str) {
@@ -67,6 +75,7 @@ var validators = module.exports = {
         }
     },
     isDecimal: function(str) {
+        if(!str.match) return false;
         return str !== '' && str.match(/^(?:-?(?:[0-9]+))?(?:\.[0-9]*)?(?:[eE][\+\-]?(?:[0-9]+))?$/);
     },
     isDivisibleBy: function(str, n) {
@@ -79,6 +88,7 @@ var validators = module.exports = {
         return str === '';
     },
     notEmpty: function(str) {
+        if(!str.match) return false;
         return !str.match(/^[\s\t\r\n]*$/);
     },
     equals: function(a, b) {


### PR DESCRIPTION
It can produce Exception when you are using expressjs with express-validator and have forms with duplicates names..

For example such form: 

<form ...>
 <input type="text" name="email"/> 
 <input type="text" name="email"/>
 ... 
 <input type="submit"/>
</form>


And then try to make on server

app.post("some_addr", function(req,res){
   req.assert("email", "Invalid email" ).notNull().isEmail();
}); 

throws error 

Something like this:
TypeError: Object boris@pavlovic.me,test, has no method 'match'
