### PR TITLE
Remove dependency to native node-module "net" 

### DIFF
--- a/lib/validators.js
+++ b/lib/validators.js
@@ -1,4 +1,3 @@
-var net = require('net');
 
 // Helper function to avoid duplication of code
 function toDateTime(date) {
@@ -30,17 +29,36 @@ var validators = module.exports = {
     isUrl: function(str) {
         return str.match(/^(?:(?:ht|f)tp(?:s?)\:\/\/|~\/|\/)?(?:\w+:\w+@)?(localhost|(?:(?:[-\w\d{1-3}]+\.)+(?:com|org|net|gov|mil|biz|info|mobi|name|aero|jobs|edu|co\.uk|ac\.uk|it|fr|tv|museum|asia|local|travel|[a-z]{2}))|((\b25[0-5]\b|\b[2][0-4][0-9]\b|\b[0-1]?[0-9]?[0-9]\b)(\.(\b25[0-5]\b|\b[2][0-4][0-9]\b|\b[0-1]?[0-9]?[0-9]\b)){3}))(?::[\d]{1,5})?(?:(?:(?:\/(?:[-\w~!$+|.,="'\(\)_\*]|%[a-f\d]{2})+)+|\/)+|\?|#)?(?:(?:\?(?:[-\w~!$+|.,*:]|%[a-f\d{2}])+=?(?:[-\w~!$+|.,*:=]|%[a-f\d]{2})*)(?:&(?:[-\w~!$+|.,*:]|%[a-f\d{2}])+=?(?:[-\w~!$+|.,*:=]|%[a-f\d]{2})*)*)*(?:#(?:[-\w~!$ |\/.,*:;=]|%[a-f\d]{2})*)?$/i) || str.length > 2083;
     },
-    isIP: function(str) {
-        // net.isIp requires node >= 0.3.0
-        var modernNode = typeof net.isIP === 'function';
-        var method = modernNode? validators.isIPNet : validators.isIPManual;
-        return method(str);
+    //node-js-core
+    isIP : function(str) {
+        if (!str) {
+            return 0;
+        } else if (/^(\d?\d?\d)\.(\d?\d?\d)\.(\d?\d?\d)\.(\d?\d?\d)$/.test(str)) {
+            var parts = str.split('.');
+            for (var i = 0; i < parts.length; i++) {
+                var part = parseInt(parts[i]);
+                if (part < 0 || 255 < part) {
+                    return 0;
+                }
+            }
+            return 4;
+        } else if (/^::|^::1|^([a-fA-F0-9]{1,4}::?){1,7}([a-fA-F0-9]{1,4})$/.test(
+            str)) {
+            return 6;
+        } else {
+            return 0;
+        }
+    },
+    //node-js-core
+    isIPv4 : function(str) {
+        return validators.isIP(str) === 4;
+    },
+    //node-js-core
+    isIPv6 : function(str) {
+        return validators.isIP(str) === 6;
     },
     isIPNet: function(str) {
-        return net.isIP(str) !== 0;
-    },
-    isIPManual: function(str) {
-        return str.match(/^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/);
+        return validators.isIP(str) !== 0;
     },
     isAlpha: function(str) {
         return str.match(/^[a-zA-Z]+$/);
@@ -59,7 +77,7 @@ var validators = module.exports = {
     },
     isInt: function(str) {
         var floatVal = parseFloat(str)
-        , intVal = parseInt(str * 1, 10);
+            , intVal = parseInt(str * 1, 10);
         if(!isNaN(intVal) && (floatVal == intVal)) {
             return true;
         } else {
@@ -163,31 +181,31 @@ var validators = module.exports = {
         var tmpNum;
         var shouldDouble = false;
         for (var i = sanitized.length - 1; i >= 0; i--) {
-                digit = sanitized.substring(i, (i + 1));
-                tmpNum = parseInt(digit, 10);
-                if (shouldDouble) {
-                    tmpNum *= 2;
-                    if (tmpNum >= 10) {
-                        sum += ((tmpNum % 10) + 1);
-                    }
-                    else {
-                        sum += tmpNum;
-                    }
+            digit = sanitized.substring(i, (i + 1));
+            tmpNum = parseInt(digit, 10);
+            if (shouldDouble) {
+                tmpNum *= 2;
+                if (tmpNum >= 10) {
+                    sum += ((tmpNum % 10) + 1);
                 }
                 else {
                     sum += tmpNum;
                 }
-                if (shouldDouble) {
-                    shouldDouble = false;
-                }
-                else {
-                    shouldDouble = true;
-                }
             }
-            if ((sum % 10) === 0) {
-                return sanitized;
-            } else {
-                return null;
+            else {
+                sum += tmpNum;
             }
+            if (shouldDouble) {
+                shouldDouble = false;
+            }
+            else {
+                shouldDouble = true;
+            }
+        }
+        if ((sum % 10) === 0) {
+            return sanitized;
+        } else {
+            return null;
+        }
     }
 };


### PR DESCRIPTION
I'm using [webpack](https://github.com/webpack/webpack) (similar to browserify) in order to use my node-modules in the browser. 

I've seen the validator.js for browser-use but doing it the node-way is more convenient for me, so i prefer using webpack over including a js-file directly. 

The problem is the dependency **net** in `validators.isIP()`, because it doesn't exist in a browser-environment. 

If you get rid of this dependency, everyone using browserify or webpack could easily bundle your validator-module. I copied the methods used in the **net** module directly into the validator.js. 

The only problem is that we have to keep the method updated with the node-version, but that should be no problem with node becoming more mature and IP-signature won't change anytime soon, right?
