### PR TITLE
fixed _errors array reset on check - exception bypass mode

### DIFF
--- a/validator.js
+++ b/validator.js
@@ -525,9 +525,9 @@
     var Validator = exports.Validator = function() {}
 
     Validator.prototype.check = function(str, fail_msg) {
-        this.str = str == null || (isNaN(str) && str.length == undefined) ? '' : str+'';
+        this.str = str === null || (isNaN(str) && str.length === undefined) ? '' : str+'';
         this.msg = fail_msg;
-        this._errors = [];
+        this._errors = this._errors || [];
         return this;
     }
 


### PR DESCRIPTION
The "exception bypass" mode suggested in the last part of the read me is not working.
The _errors array was being reseted every time a .check('something') was called.

the fix maintains the list of _errors already collected.

In the ReadMe example:

```
Validator.prototype.error = function (msg) {
     this._errors.push(msg);
}

Validator.prototype.getErrors = function () {
    return this._errors;
}

var validator = new Validator();

validator.check('abc').isEmail();
validator.check('hello').len(10,30);

var errors = validator.getErrors(); // ['Invalid email', 'String is too small']
```

The output is actually: ['String is too small'], i.e ignores first errors
