### PR TITLE
Check for 'undefined' being checked...

### DIFF
--- a/validator.js
+++ b/validator.js
@@ -525,7 +525,7 @@
     var Validator = exports.Validator = function() {}
 
     Validator.prototype.check = function(str, fail_msg) {
-        this.str = str === null || (isNaN(str) && str.length === undefined) ? '' : str+'';
+        this.str = typeof( str ) === 'undefined' || str === null || (isNaN(str) && str.length === undefined) ? '' : str+'';
         this.msg = fail_msg;
         this._errors = this._errors || [];
         return this;


### PR DESCRIPTION
I hit a bug in my code where I was accidentally passing undefined to check, but instead of throwing the error I expected, I was getting a crash on str.length check.  This avoids that crash and, at least I think, provides expected behavior if passing undefined.
