### PR TITLE
Make isBefore() and isAfter() checks really non-inclusive

### DIFF
--- a/lib/validators.js
+++ b/lib/validators.js
@@ -142,13 +142,13 @@ var validators = module.exports = {
         date = date || new Date();
         var origDate = toDate(str);
         var compDate = toDate(date);
-        return !(origDate && compDate && origDate < compDate);
+        return !(origDate && compDate && origDate <= compDate);
     },
     isBefore: function(str, date) {
         date = date || new Date();
         var origDate = toDate(str);
         var compDate = toDate(date);
-        return !(origDate && compDate && origDate > compDate);
+        return !(origDate && compDate && origDate >= compDate);
     },
     isIn: function(str, options) {
         var validOptions = options && typeof options.indexOf === 'function';

--- a/test/validator.test.js
+++ b/test/validator.test.js
@@ -589,6 +589,9 @@ module.exports = {
         assert.throws(function() {
             Validator.check(f.yesterday).isAfter();
         });
+        assert.throws(function() {
+            Validator.check('2011-09-01').isAfter('2011-09-01');
+        });
     },
 
     'test #isBefore()': function() {
@@ -602,6 +605,9 @@ module.exports = {
         });
         assert.throws(function() {
             Validator.check(f.tomorrow).isBefore();
+        });
+        assert.throws(function() {
+            Validator.check('2011-09-01').isBefore('2011-09-01');
         });
     },
 


### PR DESCRIPTION
As mentioned in #97, the `isAfter()` and `isBefore()` checks are _non-inclusive_, i.e.

```
var now = new Date();
check(now).isAfter(now); // => should return false
```

In reality, the 2 checks are actually _inclusive_, meaning that the `isAfter()` check above actually returns true as proven by the tests included in my pull request.

This commit 840836f2 removes same-day tests but forgets to test for the same-day edge case. I've put back the tests and also made the checks non-inclusive.
