### PR TITLE
Argument replacement fails on non-string validation messages

### DIFF
--- a/lib/validator.js
+++ b/lib/validator.js
@@ -25,7 +25,9 @@ for (var key in validators) {
                 args.unshift(this.str);
                 if(!validators[key].apply(this, args)) {
                     var msg = this.msg || exports.defaultError[key];
-                    args.forEach(function(arg, i) { msg = msg.replace('%'+i, arg); });
+                    if (typeof msg === 'string') {
+                        args.forEach(function(arg, i) { msg = msg.replace('%'+i, arg); });
+                    }
                     return this.error(msg);
                 }
                 return this;


### PR DESCRIPTION
I use node-validator extensively in a project, and unfortunately the tests started failing after we upgraded to the latest version of node-validator.

Because of a business requirement we have, it's not enough for us to just set a string as the validation message. Instead, we've been using an object that contains all of the properties that need to come back, which has been working really well.

```
validator.check(limit, {'key1': value1, 'key2': value2}).isInt();
```

In the latest node-validator release, a .replace is done on all validation message. As we're not using strings, but objects, I've added in a type check. This change makes our code work again and would allow us to upgrade to the next version.

Let me know if you want me to make any changes to it.
