### PR TITLE
Replaced isIP with built-in methods

### DIFF
--- a/lib/validators.js
+++ b/lib/validators.js
@@ -1,3 +1,4 @@
+var net = require('net');
 
 // Helper function to avoid duplication of code
 function toDateTime(date) {
@@ -32,22 +33,12 @@ var validators = module.exports = {
     },
     //node-js-core
     isIP : function(str) {
-        if (!str) {
+        if (!str || !net.isIP(str)) {
             return 0;
-        } else if (/^(\d?\d?\d)\.(\d?\d?\d)\.(\d?\d?\d)\.(\d?\d?\d)$/.test(str)) {
-            var parts = str.split('.');
-            for (var i = 0; i < parts.length; i++) {
-                var part = parseInt(parts[i]);
-                if (part < 0 || 255 < part) {
-                    return 0;
-                }
-            }
+        } else if (net.isIPv4(str)) {
             return 4;
-        } else if (/^::|^::1|^([a-fA-F0-9]{1,4}::?){1,7}([a-fA-F0-9]{1,4})$/.test(
-            str)) {
+        } else if (net.isIPv6(str)) {
             return 6;
-        } else {
-            return 0;
         }
     },
     //node-js-core


### PR DESCRIPTION
Tested against the test suite in 0.8.20.

From the node API docs, the method seems to exist since at least 0.3.1 - http://nodejs.org/docs/v0.3.1/api/net.html
