### PR TITLE
isEmail() and isUrl() must return false for type !== string

### DIFF
--- a/lib/validators.js
+++ b/lib/validators.js
@@ -24,9 +24,15 @@ function toDate(date) {
 
 var validators = module.exports = {
     isEmail: function(str) {
+        if (typeof str !== 'string') {
+            return false;
+        }
         return str.match(/^(?:[\w\!\#\$\%\&\'\*\+\-\/\=\?\^\`\{\|\}\~]+\.)*[\w\!\#\$\%\&\'\*\+\-\/\=\?\^\`\{\|\}\~]+@(?:(?:(?:[a-zA-Z0-9](?:[a-zA-Z0-9\-](?!\.)){0,61}[a-zA-Z0-9]?\.)+[a-zA-Z0-9](?:[a-zA-Z0-9\-](?!$)){0,61}[a-zA-Z0-9]?)|(?:\[(?:(?:[01]?\d{1,2}|2[0-4]\d|25[0-5])\.){3}(?:[01]?\d{1,2}|2[0-4]\d|25[0-5])\]))$/);
     },
     isUrl: function(str) {
+        if (typeof str !== 'string') {
+            return false;
+        }
         //A modified version of the validator from @diegoperini / https://gist.github.com/729294
         return str.length < 2083 && str.match(/^(?!mailto:)(?:(?:https?|ftp):\/\/)?(?:\S+(?::\S*)?@)?(?:(?:(?:[1-9]\d?|1\d\d|2[01]\d|22[0-3])(?:\.(?:1?\d{1,2}|2[0-4]\d|25[0-5])){2}(?:\.(?:[1-9]\d?|1\d\d|2[0-4]\d|25[0-4]))|(?:(?:[a-z\u00a1-\uffff0-9]+-?)*[a-z\u00a1-\uffff0-9]+)(?:\.(?:[a-z\u00a1-\uffff0-9]+-?)*[a-z\u00a1-\uffff0-9]+)*(?:\.(?:[a-z\u00a1-\uffff]{2,})))|localhost)(?::\d{2,5})?(?:\/[^\s]*)?$/i);
     },


### PR DESCRIPTION
In my opinion any function using a string method such as `match` must not be run with non string input.

I  test with
cd test && node run.js
is that it? What about adding script to package.json so we can run npm test?
