### PR TITLE
Added isPhoneNumber() validator

### DIFF
--- a/lib/defaultError.js
+++ b/lib/defaultError.js
@@ -30,6 +30,7 @@ var defaultError = module.exports = {
     min: 'Invalid number',
     max: 'Invalid number',
     isArray: 'Not an array',
-    isCreditCard: 'Invalid credit card'
+    isCreditCard: 'Invalid credit card',
+    isPhoneNumber: 'Invalid phone number'
 };
 

--- a/lib/validators.js
+++ b/lib/validators.js
@@ -214,5 +214,15 @@ var validators = module.exports = {
         } else {
             return null;
         }
+    },
+    isPhoneNumber: function(str, international) {
+        international = international || false
+        var pattern;
+        if(international) {
+            pattern = /^\+(?:[0-9] ?){6,14}[0-9]$/;
+        } else {
+            pattern = /^\(?([0-9]{3})\)?[-. ]?([0-9]{3})[-. ]?([0-9]{4})$/;
+        }
+        return str.match(pattern);
     }
 };

--- a/test/validator.test.js
+++ b/test/validator.test.js
@@ -634,6 +634,31 @@ module.exports = {
         });
     },
 
+    'test #isPhoneNumber()': function() {
+        // Valid US Numbers
+        assert.ok(Validator.check('(555)123-4567').isPhoneNumber());
+        assert.ok(Validator.check('5551234567').isPhoneNumber());
+        assert.ok(Validator.check('555-123-4567').isPhoneNumber());
+        assert.ok(Validator.check('(555) 123 4567').isPhoneNumber());
+        assert.ok(Validator.check('(555) 123-4567').isPhoneNumber());
+
+        // Valid International Numbers
+        assert.ok(Validator.check('+1 5551234567').isPhoneNumber(true));
+        assert.ok(Validator.check('+15551234567').isPhoneNumber(true));
+        assert.ok(Validator.check('+44 7700 954 321').isPhoneNumber(true));
+
+        // Invalid US Numbers
+        assert.throws(function() { Validator.check('foo').isPhoneNumber(); });
+        assert.throws(function() { Validator.check('555123456').isPhoneNumber(); });
+        assert.throws(function() { Validator.check('55512345678').isPhoneNumber(); });
+        assert.throws(function() { Validator.check('+1 5551234567').isPhoneNumber(); });
+
+        // Invalid International Numbers
+        assert.throws(function() { Validator.check('foo').isPhoneNumber(true); });
+        assert.throws(function() { Validator.check('(555) 123-4567').isPhoneNumber(true); });
+        assert.throws(function() { Validator.check('1234567890').isPhoneNumber(true); });
+    },    
+
     'test error is instanceof ValidatorError': function() {
         try {
             Validator.check('not_an_email', 'Invalid').isEmail();


### PR DESCRIPTION
Added isPhoneNumber() validator.

isPhoneNumber(international)

international is optional boolean that defaults to false and determines validation pattern.
