### PR TITLE
fixes node-version of isInt() to work as stated in README

### DIFF
--- a/lib/validators.js
+++ b/lib/validators.js
@@ -83,13 +83,7 @@ var validators = module.exports = {
         return str.match(/^[A-Z0-9]+$/);
     },
     isInt: function(str) {
-        var floatVal = parseFloat(str)
-            , intVal = parseInt(str * 1, 10);
-        if(!isNaN(intVal) && (floatVal == intVal)) {
-            return true;
-        } else {
-            return false;
-        }
+        return str.match(/^(?:-?(?:0|[1-9][0-9]*))$/);
     },
     isDecimal: function(str) {
         return str !== '' && str.match(/^(?:-?(?:[0-9]+))?(?:\.[0-9]*)?(?:[eE][\+\-]?(?:[0-9]+))?$/);

--- a/test/validator.test.js
+++ b/test/validator.test.js
@@ -212,12 +212,8 @@ module.exports = {
         assert.ok(Validator.check(0).isInt());
         assert.ok(Validator.check(123).isInt());
         assert.ok(Validator.check('-0').isInt());
-        assert.ok(Validator.check('01').isInt());
-        assert.ok(Validator.check('-01').isInt());
-        assert.ok(Validator.check('000').isInt());
-        assert.ok(Validator.check('100e10').isInt());
 
-        ['123.123','  ',''].forEach(function(str) {
+        ['01', '-01', '000', '100e10', '123.123', '  ', ''].forEach(function(str) {
             try {
                 Validator.check(str).isInt();
                 assert.ok(false, 'falsepositive');


### PR DESCRIPTION
the node-version of isInt() did not fail on zeropadded numbers.
Updated node-versions code to the working code of the browser-version.
