### PR TITLE
toLowercase() and toUppercase() fail on foreign characters

### DIFF
--- a/lib/validators.js
+++ b/lib/validators.js
@@ -77,10 +77,10 @@ var validators = module.exports = {
         return str.match(/^#?([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/);
     },
     isLowercase: function(str) {
-        return str.match(/^[a-z0-9]+$/);
+        return str === str.toLowerCase();
     },
     isUppercase: function(str) {
-        return str.match(/^[A-Z0-9]+$/);
+        return str === str.toUpperCase();
     },
     isInt: function(str) {
         var floatVal = parseFloat(str)

--- a/test/validator.test.js
+++ b/test/validator.test.js
@@ -182,6 +182,8 @@ module.exports = {
         assert.ok(Validator.check('a').isLowercase());
         assert.ok(Validator.check('123').isLowercase());
         assert.ok(Validator.check('abc123').isLowercase());
+        assert.ok(Validator.check('this is lowercase.').isLowercase());
+        assert.ok(Validator.check('très über').isLowercase());
 
         ['123A','ABC','.',''].forEach(function(str) {
             try {

--- a/validator.js
+++ b/validator.js
@@ -666,14 +666,14 @@
     }
 
     Validator.prototype.isLowercase = function() {
-        if (!this.str.match(/^[a-z0-9]+$/)) {
+        if (this.str !== this.str.toLowerCase()) {
             return this.error(this.msg || 'Invalid characters');
         }
         return this;
     }
 
     Validator.prototype.isUppercase = function() {
-        if (!this.str.match(/^[A-Z0-9]+$/)) {
+        if (this.str !== this.str.toUpperCase()) {
             return this.error(this.msg || 'Invalid characters');
         }
         return this;


### PR DESCRIPTION
isLowercase() and isUppercase() failed on whitespace, punctuation marks and non-ascii letters because of a too strict regular expression check. Changed it to compare the given string to the result of the native toLowerCase() or toUpperCase() functions.
