### PR TITLE
contains() passes with empty strings

### DIFF
--- a/lib/validators.js
+++ b/lib/validators.js
@@ -110,7 +110,7 @@ var validators = module.exports = {
         return a == b;
     },
     contains: function(str, elem) {
-        return str.indexOf(elem) >= 0;
+        return str.indexOf(elem) >= 0 && !!elem;
     },
     notContains: function(str, elem) {
         return !validators.contains(str, elem);

--- a/test/validator.test.js
+++ b/test/validator.test.js
@@ -324,7 +324,11 @@ module.exports = {
         assert.ok(Validator.check('foobar').contains('oo'));
         assert.ok(Validator.check('abc').contains('a'));
         assert.ok(Validator.check('  ').contains(' '));
-        assert.ok(Validator.check('abc').contains(''));
+
+        try {
+            Validator.check('abc').contains('');
+            assert.ok(false, 'contains failed');
+        } catch (e) {}
 
         try {
             Validator.check(123).contains('abc');

--- a/validator.js
+++ b/validator.js
@@ -726,7 +726,7 @@
     }
 
     Validator.prototype.contains = function(str) {
-        if (this.str.indexOf(str) === -1) {
+        if (this.str.indexOf(str) === -1 || !str) {
             return this.error(this.msg || 'Invalid characters');
         }
         return this;


### PR DESCRIPTION
Changed contains() to fail on things like `"abc".contains("")` as there is no empty string within `"abc"`.
