### PR TITLE
Coerce notIn() argument to a string

### DIFF
--- a/lib/validators.js
+++ b/lib/validators.js
@@ -176,8 +176,13 @@ var validators = module.exports = {
         return options.indexOf(str) >= 0;
     },
     notIn: function(str, options) {
-        var validOptions = options && typeof options.indexOf === 'function';
-        return validOptions && options.indexOf(str) === -1;
+        if (!options || typeof options.indexOf !== 'function') {
+            return false;
+        }
+        if (Array.isArray(options)) {
+            options = options.map(String);
+        }
+        return options.indexOf(str) < 0;
     },
     min: function(str, val) {
         var number = parseFloat(str);

--- a/test/validator.test.js
+++ b/test/validator.test.js
@@ -501,6 +501,10 @@ module.exports = {
         );
 
         assert.throws(function() {
+            Validator.check('1').notIn([1, 2, 3]);
+        }, /unexpected/i);
+
+        assert.throws(function() {
             Validator.check('foo').notIn(1234567);
           }, /invalid/i
         );


### PR DESCRIPTION
I added the same behavior as in 5c4cbf7616e06f86a65266db1d88646e9c0e770d to notIn().
