### PR TITLE
Exclude boolean, number, and function types from xss clean

### DIFF
--- a/lib/xss.js
+++ b/lib/xss.js
@@ -50,6 +50,8 @@ exports.clean = function(str, is_image) {
         return str;
     }
 
+    if (typeof str === 'boolean' || typeof str === 'function' || typeof str === 'number') return str;
+
     //Remove invisible characters
     str = remove_invisible_characters(str);
 


### PR DESCRIPTION
This issue comes after the fix submitted here:

https://github.com/chriso/node-validator/issues/189

Once xss() is able to clean objects, the clean function breaks if the input object contains boolean, number, or function fields.
