### PR TITLE
validator for Canada post codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ notIn(options)
 max(val)
 min(val)
 isCreditCard()                  //Will work against Visa, MasterCard, American Express, Discover, Diners Club, and JCB card numbering formats
+isCanadaPostCode()              //Accepts both spaced and non-spaced formats (e.g. H2G 1M1 & H2G1M1)
 ```
 
 ## List of sanitization / filter methods

--- a/lib/defaultError.js
+++ b/lib/defaultError.js
@@ -30,6 +30,7 @@ var defaultError = module.exports = {
     min: 'Invalid number',
     max: 'Invalid number',
     isArray: 'Not an array',
-    isCreditCard: 'Invalid credit card'
+    isCreditCard: 'Invalid credit card',
+    isCanadaPostCode: 'Invalid Canada post code'
 };
 

--- a/lib/validators.js
+++ b/lib/validators.js
@@ -231,5 +231,9 @@ var validators = module.exports = {
         } else {
             return null;
         }
+    },
+    //Accepts both spaced and non-spaced formats (e.g. H2G 1M1 & H2G1M1)
+    isCanadaPostCode: function(str, options) {
+        return str.match(/^[ABCEGHJKLMNPRSTVXY]{1}\d{1}[A-Z]{1} *\d{1}[A-Z]{1}\d{1}$/);
     }
 };


### PR DESCRIPTION
Validator for Canada post codes. It accepts both spaced and non-spaced
formats (e.g. H2G 1M1 & H2G1M1)
