### PR TITLE
Only match evil HTML attributes on word boundaries

### DIFF
--- a/lib/xss.js
+++ b/lib/xss.js
@@ -135,7 +135,7 @@ exports.clean = function(str, is_image) {
     } while(original !== str);
 
     // Remove Evil HTML Attributes (like event handlers and style)
-    var event_handlers = ['on\\w*', 'style', 'formaction'];
+    var event_handlers = ['\\bon\\w*', '\\bstyle', '\\bformaction'];
 
     //Adobe Photoshop puts XML metadata into JFIF images, including namespacing,
     //so we have to allow this for images


### PR DESCRIPTION
Prevents words containing (but not starting with) 'on' from being XSS filtered (see #201).
