### PR TITLE
save custom error objects to this.msg

### DIFF
--- a/lib/validator.js
+++ b/lib/validator.js
@@ -35,7 +35,7 @@ Validator.prototype.check = function(str, fail_msg) {
     // This is a key, value pair of error messages to use
     if (typeof fail_msg === 'object') {
         this.errorDictionary = fail_msg;
-        this.msg = null
+        this.msg = fail_msg;
     }
     else {
         this.errorDictionary = {};


### PR DESCRIPTION
I commented in #207 about this. A project I work on is passing a custom error object like `{code: 404, msg: 'Not Found'}` as the message in our validators. The latest versions of validator break this by leaving `this.msg` as `null` when the message is an Object.
