### PR TITLE
Allow underscores in subdomains

### DIFF
--- a/lib/validators.js
+++ b/lib/validators.js
@@ -28,7 +28,7 @@ var validators = module.exports = {
     },
     isUrl: function(str) {
         //A modified version of the validator from @diegoperini / https://gist.github.com/729294
-        return str.length < 2083 && str.match(/^(?!mailto:)(?:(?:https?|ftp):\/\/)?(?:\S+(?::\S*)?@)?(?:(?:(?:[1-9]\d?|1\d\d|2[01]\d|22[0-3])(?:\.(?:1?\d{1,2}|2[0-4]\d|25[0-5])){2}(?:\.(?:[0-9]\d?|1\d\d|2[0-4]\d|25[0-4]))|(?:(?:[a-z\u00a1-\uffff0-9]+-?)*[a-z\u00a1-\uffff0-9]+)(?:\.(?:[a-z\u00a1-\uffff0-9]+-?)*[a-z\u00a1-\uffff0-9]+)*(?:\.(?:[a-z\u00a1-\uffff]{2,})))|localhost)(?::\d{2,5})?(?:\/[^\s]*)?$/i);
+        return str.length < 2083 && str.match(/^(?!mailto:)(?:(?:https?|ftp):\/\/)?(?:\S+(?::\S*)?@)?(?:(?:(?:[1-9]\d?|1\d\d|2[01]\d|22[0-3])(?:\.(?:1?\d{1,2}|2[0-4]\d|25[0-5])){2}(?:\.(?:[1-9]\d?|1\d\d|2[0-4]\d|25[0-4]))|(?:(?:[a-z\_\u00a1-\uffff0-9]+-?)*[a-z\_\u00a1-\uffff0-9]+)(?:\.(?:[a-z\u00a1-\uffff0-9]+-?)*[a-z\u00a1-\uffff0-9]+)*(?:\.(?:[a-z\u00a1-\uffff]{2,})))|localhost)(?::\d{2,5})?(?:\/[^\s]*)?$/i);
     },
     //node-js-core
     isIP : function(str) {

--- a/test/validator.test.js
+++ b/test/validator.test.js
@@ -89,7 +89,8 @@ module.exports = {
             'http://189.123.14.13/',
             'http://duckduckgo.com/?q=%2F',
             'http://foobar.com/t$-_.+!*\'(),',
-            'http://localhost:3000/'
+            'http://localhost:3000/',
+            'http://foo_bar.foobar.com/'
         ];
         try {
             valid.forEach(function(url) {


### PR DESCRIPTION
The URL validator doesn't accept underscores in subdomains, even though it is a valid character to use.
