### PR TITLE
enhance bower support

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
   "name": "validator-js",
   "main": "validator.js",
   "version": "3.8.1",
-  "homepage": "https://github.com/christo/validator.js",
+  "homepage": "https://github.com/chriso/validator.js",
   "authors": [
     "Chris O'Hara <cohara87+gh@gmail.com>"
   ],


### PR DESCRIPTION
If you use something like wiredep, since this project lacks a "main" property in bower.json you will get an error like
![screenshot 2014-04-14 15 42 43](https://cloud.githubusercontent.com/assets/2192970/2700649/0c664a74-c416-11e3-8bea-86e7134ada8c.png)

Adding a proper bower.json fixes this
