### PR TITLE
 change hash test regex to include uppercase chars

### DIFF
--- a/validator.js
+++ b/validator.js
@@ -1051,7 +1051,7 @@ var lengths = {
 };
 function isHash(str, algorithm) {
   assertString(str);
-  var hash = new RegExp("^[a-f0-9]{".concat(lengths[algorithm], "}$"));
+  var hash = new RegExp("^[a-fA-F0-9]{".concat(lengths[algorithm], "}$"));
   return hash.test(str);
 }
 


### PR DESCRIPTION
isHash returns false if hash is upper case, this can be fixed by adding upper case letters to the regex