### PR TITLE
fix(README): link to contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ $ bower install validator-js
 
 Thank you to the people who have already contributed:
 
-<a href="graphs/contributors"><img src="https://opencollective.com/validatorjs/contributors.svg?width=890" /></a>
+<a href="https://github.com/validatorjs/validator.js/graphs/contributors"><img src="https://opencollective.com/validatorjs/contributors.svg?width=890" /></a>
 
 ## Validators
 


### PR DESCRIPTION
The (relative) link to contributors was defaulting to `/blob/master/graph/contributors` (hence 404), I made it absolute instead.