### PR TITLE
Removed tests on hash part of URL

### DIFF
--- a/src/lib/isURL.js
+++ b/src/lib/isURL.js
@@ -33,7 +33,7 @@ function checkHost(host, matches) {
 
 export default function isURL(url, options) {
   assertString(url);
-  
+
   if (!url || url.length >= 2083) {
     return false;
   }
@@ -41,7 +41,7 @@ export default function isURL(url, options) {
   if (url.indexOf('mailto:') === 0) {
     return false;
   }
-  
+
   options = merge(options, default_url_options);
   let protocol, auth, host, hostname, port, port_str, split, ipv6;
   split = url.split('#');
@@ -49,10 +49,10 @@ export default function isURL(url, options) {
   split = url.split('?');
   url = split.shift();
 
-  if(/[\s<>]/.test(url)){
+  if (/[\s<>]/.test(url)) {
     return false;
   }
-  
+
   split = url.split('://');
   if (split.length > 1) {
     protocol = split.shift().toLowerCase();

--- a/src/lib/isURL.js
+++ b/src/lib/isURL.js
@@ -33,21 +33,31 @@ function checkHost(host, matches) {
 
 export default function isURL(url, options) {
   assertString(url);
-  if (!url || url.length >= 2083 || /[\s<>]/.test(url)) {
+  
+  if (!url) {
     return false;
   }
+
   if (url.indexOf('mailto:') === 0) {
     return false;
   }
+  
   options = merge(options, default_url_options);
   let protocol, auth, host, hostname, port, port_str, split, ipv6;
-
   split = url.split('#');
   url = split.shift();
+  
+  if(url.length >= 2083){
+    return false;
+  }
 
   split = url.split('?');
   url = split.shift();
 
+  if(/[\s<>]/.test(url)){
+    return false;
+  }
+  
   split = url.split('://');
   if (split.length > 1) {
     protocol = split.shift().toLowerCase();

--- a/src/lib/isURL.js
+++ b/src/lib/isURL.js
@@ -34,7 +34,7 @@ function checkHost(host, matches) {
 export default function isURL(url, options) {
   assertString(url);
   
-  if (!url) {
+  if (!url || url.length >= 2083) {
     return false;
   }
 
@@ -46,11 +46,6 @@ export default function isURL(url, options) {
   let protocol, auth, host, hostname, port, port_str, split, ipv6;
   split = url.split('#');
   url = split.shift();
-  
-  if(url.length >= 2083){
-    return false;
-  }
-
   split = url.split('?');
   url = split.shift();
 

--- a/test/validators.js
+++ b/test/validators.js
@@ -534,6 +534,18 @@ describe('Validators', () => {
       ],
     });
   });
+  
+  it('should validate URLs with underscores', () => {
+    test({
+      validator: 'isURL',
+      args: [],
+      valid: [
+        'http://foo_bar.com#>part1',
+        'http://foo_bar.com#id with space'
+      ],
+      invalid: [],
+    });
+  });
 
   it('should let users specify a host whitelist', () => {
     test({


### PR DESCRIPTION

I've moved the test around so they only affect the proper URL part.

Specifically, the tests which ensures there are no spaces or < > symbols, should not be ran on the complete URL.
Instead, they should be ran on the host and path part only, not on the query string and hash.

Relevant issue: https://github.com/validatorjs/validator.js/issues/936