### PR TITLE
Added validation for '0x'-prefixed hex strings.

### DIFF
--- a/lib/isHexadecimal.js
+++ b/lib/isHexadecimal.js
@@ -9,7 +9,7 @@ var _assertString = _interopRequireDefault(require("./util/assertString"));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-var hexadecimal = /^[0-9A-F]+$/i;
+var hexadecimal = /^(0x)?[0-9A-F]+$/i;
 
 function isHexadecimal(str) {
   (0, _assertString.default)(str);

--- a/src/lib/isHexadecimal.js
+++ b/src/lib/isHexadecimal.js
@@ -1,6 +1,6 @@
 import assertString from './util/assertString';
 
-const hexadecimal = /^[0-9A-F]+$/i;
+const hexadecimal = /^(0x)?[0-9A-F]+$/i;
 
 export default function isHexadecimal(str) {
   assertString(str);

--- a/src/lib/isHexadecimal.js
+++ b/src/lib/isHexadecimal.js
@@ -1,6 +1,6 @@
 import assertString from './util/assertString';
 
-const hexadecimal = /^(0x)?[0-9A-F]+$/i;
+const hexadecimal = /^(0x|0h)?[0-9A-F]+$/i;
 
 export default function isHexadecimal(str) {
   assertString(str);

--- a/test/validators.js
+++ b/test/validators.js
@@ -2495,11 +2495,15 @@ describe('Validators', () => {
       valid: [
         'deadBEEF',
         'ff0044',
+        '0xff0044',
+        '0XfF0044',
       ],
       invalid: [
         'abcdefg',
         '',
         '..',
+        '0xa2h',
+        '0xa20x',
       ],
     });
   });

--- a/test/validators.js
+++ b/test/validators.js
@@ -2497,6 +2497,11 @@ describe('Validators', () => {
         'ff0044',
         '0xff0044',
         '0XfF0044',
+        '0x0123456789abcDEF',
+        '0X0123456789abcDEF',
+        '0hfedCBA9876543210',
+        '0HfedCBA9876543210',
+        '0123456789abcDEF',
       ],
       invalid: [
         'abcdefg',
@@ -2504,6 +2509,9 @@ describe('Validators', () => {
         '..',
         '0xa2h',
         '0xa20x',
+        '0x0123456789abcDEFq',
+        '0hfedCBA9876543210q',
+        '01234q56789abcDEF',
       ],
     });
   });


### PR DESCRIPTION
* Modified isHexdecimal to allow validation of hexdecimal strings prefixed with the standard '0x'. The '0x' prefix is not required but if it does exist in the string, it is still OK.
* Updated validator.js to include a few more test cases involving the '0x' prefix

Update:
* Added '0h' prefix as a valid hexadecimal format.