### PR TITLE
Added isOctal validator including tests and updated README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Validator                               | Description
 **isMongoId(str)**                      | check if the string is a valid hex-encoded representation of a [MongoDB ObjectId][mongoid].
 **isMultibyte(str)**                    | check if the string contains one or more multibyte chars.
 **isNumeric(str [, options])**                      | check if the string contains only numbers.<br/><br/>`options` is an object which defaults to `{no_symbols: false}`. If `no_symbols` is true, the validator will reject numeric strings that feature a symbol (e.g. `+`, `-`, or `.`).
+**isOctal(str)**                        | check if the string is a valid octal number.
 **isPort(str)**                         | check if the string is a valid port number.
 **isPostalCode(str, locale)**           | check if the string is a postal code,<br/><br/>(locale is one of `[ 'AD', 'AT', 'AU', 'BE', 'BG', 'BR', 'CA', 'CH', 'CZ', 'DE', 'DK', 'DZ', 'EE', 'ES', 'FI', 'FR', 'GB', 'GR', 'HR', 'HU', 'ID', 'IE' 'IL', 'IN', 'IS', 'IT', 'JP', 'KE', 'LI', 'LT', 'LU', 'LV', 'MT', 'MX', 'NL', 'NO', 'NZ', 'PL', 'PR', 'PT', 'RO', 'RU', 'SA', 'SE', 'SI', 'TN', 'TW', 'UA', 'US', 'ZA', 'ZM' ]` OR 'any'. If 'any' is used, function will check if any of the locals match. Locale list is `validator.isPostalCodeLocales`.).
 **isSurrogatePair(str)**                | check if the string contains any surrogate pairs chars.

--- a/src/index.js
+++ b/src/index.js
@@ -33,6 +33,7 @@ import isInt from './lib/isInt';
 import isFloat, { locales as isFloatLocales } from './lib/isFloat';
 import isDecimal from './lib/isDecimal';
 import isHexadecimal from './lib/isHexadecimal';
+import isOctal from './lib/isOctal';
 import isDivisibleBy from './lib/isDivisibleBy';
 
 import isHexColor from './lib/isHexColor';
@@ -135,6 +136,7 @@ const validator = {
   isFloatLocales,
   isDecimal,
   isHexadecimal,
+  isOctal,
   isDivisibleBy,
   isHexColor,
   isISRC,

--- a/src/lib/isOctal.js
+++ b/src/lib/isOctal.js
@@ -1,0 +1,8 @@
+import assertString from './util/assertString';
+
+const octal = /^(0o)?[0-7]+$/i;
+
+export default function isOctal(str) {
+  assertString(str);
+  return octal.test(str);
+}

--- a/test/validators.js
+++ b/test/validators.js
@@ -2504,6 +2504,24 @@ describe('Validators', () => {
     });
   });
 
+  it('should validate octal strings', () => {
+    test({
+      validator: 'isOctal',
+      valid: [
+        '076543210',
+        '0o01234567',
+      ],
+      invalid: [
+        'abcdefg',
+        '012345678',
+        '012345670c',
+        '00c12345670c',
+        '',
+        '..',
+      ],
+    });
+  });
+
   it('should validate hexadecimal color strings', () => {
     test({
       validator: 'isHexColor',


### PR DESCRIPTION
Added a validator `isOctal(str)` to validate strings intended to be octal numbers. It is intended for general octal numbers. It also accepts the common prefix of '0c' although it is not required to have the prefix to validate.

Changes:
* `README.md` has been updated to reflect the new isOctal addition
* `src/lib/isOctal.js` source of the validator function
* `src/index.js` modified to include `isOctal`
* `test/validators.js` added test cases to test `isOctal`
