### PR TITLE
Add validator for a 19 digit credit card number

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -66,6 +66,7 @@ import isIdentityCard from './lib/isIdentityCard';
 import isISIN from './lib/isISIN';
 import isISBN from './lib/isISBN';
 import isISSN from './lib/isISSN';
+import is19DigitCreditCard from './lib/is19DigitCreditCard';
 
 import isMobilePhone, { locales as isMobilePhoneLocales } from './lib/isMobilePhone';
 
@@ -156,6 +157,7 @@ const validator = {
   isIn,
   isCreditCard,
   isIdentityCard,
+  is19DigitCreditCard,
   isISIN,
   isISBN,
   isISSN,

--- a/src/lib/is19DigitCreditCard.js
+++ b/src/lib/is19DigitCreditCard.js
@@ -1,0 +1,8 @@
+import assertString from './util/assertString';
+
+const creditCardNumber_19 = /[0-9]{19}/;
+
+export default function is19DigitCreditCard(str) {
+  assertString(str);
+  return creditCardNumber_19.test(str);
+}

--- a/test/validators.js
+++ b/test/validators.js
@@ -7080,3 +7080,21 @@ describe('Validators', () => {
     });
   });
 });
+
+it('should validate 19 digit credit card strings', () => {
+  test({
+    validator: 'is19DigitCreditCard',
+    valid: [
+      '1234567890123456789',
+      '0234563890123476780',
+    ],
+    invalid: [
+      '123456789012345678',
+      'A123456789012345678',
+      'a123456789012345678',
+      'jasdhgjhasdf8732568',
+      '12345',
+    ],
+  });
+});
+


### PR DESCRIPTION
Implemented validation for a 19 digit credit card number.
Please tag this as [hacktoberfest](https://hacktoberfest.digitalocean.com/) issue.