### PR TITLE
IP validation with port included in ipv4

### DIFF
--- a/src/lib/isIP.js
+++ b/src/lib/isIP.js
@@ -11,18 +11,19 @@ export default function isIP(str, version = '') {
   if (!version) {
     return isIP(str, 4) || isIP(str, 6);
   } else if (version === '4') {
-    if(ipv4WithPortMaybe.test(str)){
+    if (ipv4WithPortMaybe.test(str)) {
       const ipAddress = str.split(':')[0].split('.').sort((a, b) => a - b);
       const port = str.split(':')[1];
-      if(ipAddress[3]<=255 && port<= 49151){
-        // port range is from 1 to 64738 but ports from 49152 to 64738 are for dynamic or private ports that cannot be registered with IANA
+      if (ipAddress[3] <= 255 && port <= 49151) {
+        // port range is from 1 to 64738 but ports from 49152 to 64738
+        // these are for dynamic or private ports that cannot be registered with IANA
         // referance : https://en.wikipedia.org/wiki/List_of_TCP_and_UDP_port_numbers
         return true;
       }
-    }else if(ipv4Maybe.test(str)){
+    } else if (ipv4Maybe.test(str)) {
       const parts = str.split('.').sort((a, b) => a - b);
       return parts[3] <= 255;
-    }else{
+    } else {
       return false;
     }
   } else if (version === '6') {


### PR DESCRIPTION
i have included the IPV4 validation with port. Please do have a look at this
issue link : https://github.com/validatorjs/validator.js/issues/1176