### PR TITLE
Support CSS Colors Level 4 spec

### DIFF
--- a/src/lib/isHexColor.js
+++ b/src/lib/isHexColor.js
@@ -1,6 +1,6 @@
 import assertString from './util/assertString';
 
-const hexcolor = /^#?([0-9A-F]{3}|[0-9A-F]{6})$/i;
+const hexcolor = /^#?([0-9A-F]{3}|[0-9A-F]{4}|[0-9A-F]{6}|[0-9A-F]{8})$/i;
 
 export default function isHexColor(str) {
   assertString(str);

--- a/test/validators.js
+++ b/test/validators.js
@@ -2588,14 +2588,16 @@ describe('Validators', () => {
     test({
       validator: 'isHexColor',
       valid: [
+        '#ff0000ff',
         '#ff0034',
         '#CCCCCC',
+        '0f38',
         'fff',
         '#f00',
       ],
       invalid: [
         '#ff',
-        'fff0',
+        'fff0a',
         '#ff12FG',
       ],
     });


### PR DESCRIPTION
The [CSS Color Module Level 4 Working Draft](https://drafts.csswg.org/css-color/#colorunits) now supports 4 or 8-digit hex colors (using the last bits for alpha transparency). 

It's already supported in [every major browser but IE](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value#Browser_compatibility) and will be supported in IE soon with their imminent switch to [Chromium](https://www.techcentral.ie/microsoft-to-begin-replacing-edge-with-its-chromium-based-browser-this-week/).