### PR TITLE
Add better validation for EirCode IE

### DIFF
--- a/es/lib/isPostalCode.js
+++ b/es/lib/isPostalCode.js
@@ -26,7 +26,7 @@ var patterns = {
   HR: /^([1-5]\d{4}$)/,
   HU: fourDigit,
   ID: fiveDigit,
-  IE: /^[A-z]\d[\d|w]\s\w{4}$/i,
+  IE: /^(?!.*(?:o))[A-z]\d[\dw]\s\w{4}$/i,
   IL: fiveDigit,
   IN: /^((?!10|29|35|54|55|65|66|86|87|88|89)[1-9][0-9]{5})$/,
   IS: threeDigit,

--- a/lib/isPostalCode.js
+++ b/lib/isPostalCode.js
@@ -37,7 +37,7 @@ var patterns = {
   HR: /^([1-5]\d{4}$)/,
   HU: fourDigit,
   ID: fiveDigit,
-  IE: /^[A-z]\d[\d|w]\s\w{4}$/i,
+  IE: /^(?!.*(?:o))[A-z]\d[\dw]\s\w{4}$/i,
   IL: fiveDigit,
   IN: /^((?!10|29|35|54|55|65|66|86|87|88|89)[1-9][0-9]{5})$/,
   IS: threeDigit,

--- a/src/lib/isPostalCode.js
+++ b/src/lib/isPostalCode.js
@@ -28,7 +28,7 @@ const patterns = {
   HR: /^([1-5]\d{4}$)/,
   HU: fourDigit,
   ID: fiveDigit,
-  IE: /^[A-z]\d[\d|w]\s\w{4}$/i,
+  IE: /^(?!.*(?:o))[A-z]\d[\dw]\s\w{4}$/i,
   IL: fiveDigit,
   IN: /^((?!10|29|35|54|55|65|66|86|87|88|89)[1-9][0-9]{5})$/,
   IS: threeDigit,

--- a/test/validators.js
+++ b/test/validators.js
@@ -6937,6 +6937,7 @@ describe('Validators', () => {
           'AW5 TF12',
           '756  90HG',
           'A65T F12',
+          'O62 O1O2',
         ],
       },
       {


### PR DESCRIPTION
I was implementing the isPostalCode and was looking for Ireland's postal code (eircode). Looking in the documentation of Ireland i found that the letter O is not used to avoid confusion with the digit 0.

> An Eircode is a seven character alpha-numeric code made up of two parts. The first part (a Routing Key) consists of three characters and defines a principal post town span of delivery. The second part (a Unique Identifier) is unique to an address and distinguishes one address from another. A typical Eircode might read A65 F4E2. To avoid confusion, we have not used the letter 'O' in Eircodes, however the number '0' (zero) may be included in the Eircode for your address.

**Old regex**
`/^[A-z]\d[\d|w]\s\w{4}$/i`
In this code the pipe `|` is literally a check on the if the `|` as a char is present, and not the or sign.

**New regex**
`/^(?!.*(?:o))[A-z]\d[\dw]\s\w{4}$/i`
In this code we check if there is in the whole string the character `O` is present if there is the regex don't match.

**Documentation**
[documentation eircode.ie](https://www.eircode.ie/faqs#EircodeDesign)
[eircode-routing-keys](http://www.ossiansmyth.ie/eircode-routing-keys/)
[regex101](https://regex101.com/r/oZqmNx/1/)