### PR TITLE
isFQDN option `require_tld` also supports an array to support validating against known values

### DIFF
--- a/src/lib/isFQDN.js
+++ b/src/lib/isFQDN.js
@@ -30,6 +30,10 @@ export default function isFQDN(str, options) {
     if (/[\s\u2002-\u200B\u202F\u205F\u3000\uFEFF\uDB40\uDC20]/.test(tld)) {
       return false;
     }
+    if (Array.isArray(options.require_tld)) {
+      // TODO Array.includes though for browser BC does this
+      return options.require_tld.indexOf(tld) !== -1;
+    }
   }
   for (let part, i = 0; i < parts.length; i++) {
     part = parts[i];

--- a/test/validators.js
+++ b/test/validators.js
@@ -855,6 +855,21 @@ describe('Validators', () => {
       ],
     });
   });
+  it('should validate FQDN with "require_tld" as an array of possible TLD', () => {
+    test({
+      validator: 'isFQDN',
+      args: [
+        { require_tld: ['valid'] },
+      ],
+      valid: [
+        'example.valid',
+      ],
+      invalid: [
+        'example',
+        'example.invalid',
+      ],
+    });
+  });
 
   it('should validate alpha strings', () => {
     test({

--- a/test/validators.js
+++ b/test/validators.js
@@ -841,6 +841,20 @@ describe('Validators', () => {
       ],
     });
   });
+  it('should validate FQDN with "require_tld" as true', () => {
+    test({
+      validator: 'isFQDN',
+      args: [
+        { require_tld: true },
+      ],
+      valid: [
+        'example.tld',
+      ],
+      invalid: [
+        'example',
+      ],
+    });
+  });
 
   it('should validate alpha strings', () => {
     test({


### PR DESCRIPTION
This just adds the possibility of validating against a list of given TLD values...

The `require_tld` option can now be a `boolean` (backwards compatibility) or an `array` of TLDs which first applies `require_tld: true` logic and then that the possible TLD is in the passed `array`.

* `localhost` IS NOT `require_tld: true`
* `localhost.tld` IS `require_tld: true`
* `localhost` IS NOT `require_tld: ["tld"]`
* `localhost.tld` IS `require_tld: ["tld"]`
* `localhost.example` IS NOT `require_tld: ["tld"]`

This gives more options to the developer, for example, checking the TLD against the [IANA gTLD list](http://data.iana.org/TLD/tlds-alpha-by-domain.txt) 

Checking against the list itself SHOULD NOT be part of the library.

solves https://github.com/validatorjs/validator.js/issues/1193 https://github.com/validatorjs/validator.js/issues/1247 https://github.com/validatorjs/validator.js/issues/704 https://github.com/validatorjs/validator.js/pull/1180

:hugs: 

