### PR TITLE
Allow MAC address with dots

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Validator                               | Description
 **isLength(str [, options])**              | check if the string's length falls in a range.<br/><br/>`options` is an object which defaults to `{min:0, max: undefined}`. Note: this function takes into account surrogate pairs.
 **isLocale(str)**                       | check if the string is a locale
 **isLowercase(str)**                    | check if the string is lowercase.
-**isMACAddress(str)**                   | check if the string is a MAC address.<br/><br/>`options` is an object which defaults to `{no_colons: false}`. If `no_colons` is true, the validator will allow MAC addresses without the colons. Also, it allows the use of hyphens or spaces e.g  '01 02 03 04 05 ab' or '01-02-03-04-05-ab'.
+**isMACAddress(str)**                   | check if the string is a MAC address.<br/><br/>`options` is an object which defaults to `{no_colons: false}`. If `no_colons` is true, the validator will allow MAC addresses without the colons. Also, it allows the use of hyphens, spaces or dots e.g  '01 02 03 04 05 ab', '01-02-03-04-05-ab' or '0102.0304.05ab'.
 **isMagnetURI(str)**                      | check if the string is a [magnet uri format](https://en.wikipedia.org/wiki/Magnet_URI_scheme).
 **isMD5(str)**                          | check if the string is a MD5 hash.<br/><br/>Please note that you can also use the `isHash(str, 'md5')` function. Keep in mind that MD5 has some collision weaknesses compared to other algorithms (e.g., SHA).
 **isMimeType(str)**                     | check if the string matches to a valid [MIME type](https://en.wikipedia.org/wiki/Media_type) format

--- a/src/lib/isMACAddress.js
+++ b/src/lib/isMACAddress.js
@@ -4,11 +4,16 @@ const macAddress = /^([0-9a-fA-F][0-9a-fA-F]:){5}([0-9a-fA-F][0-9a-fA-F])$/;
 const macAddressNoColons = /^([0-9a-fA-F]){12}$/;
 const macAddressWithHyphen = /^([0-9a-fA-F][0-9a-fA-F]-){5}([0-9a-fA-F][0-9a-fA-F])$/;
 const macAddressWithSpaces = /^([0-9a-fA-F][0-9a-fA-F]\s){5}([0-9a-fA-F][0-9a-fA-F])$/;
+const macAddressWithDots = /^([0-9a-fA-F]{4}).([0-9a-fA-F]{4}).([0-9a-fA-F]{4})$/;
 
 export default function isMACAddress(str, options) {
   assertString(str);
   if (options && options.no_colons) {
     return macAddressNoColons.test(str);
   }
-  return macAddress.test(str) || macAddressWithHyphen.test(str) || macAddressWithSpaces.test(str);
+
+  return macAddress.test(str)
+    || macAddressWithHyphen.test(str)
+    || macAddressWithSpaces.test(str)
+    || macAddressWithDots.test(str);
 }

--- a/test/validators.js
+++ b/test/validators.js
@@ -638,6 +638,7 @@ describe('Validators', () => {
         'A9 C5 D4 9F EB D3',
         '01 02 03 04 05 ab',
         '01-02-03-04-05-ab',
+        '0102.0304.05ab',
       ],
       invalid: [
         'abc',
@@ -647,6 +648,7 @@ describe('Validators', () => {
         'AB:CD:EF:GH:01:02',
         'A9C5 D4 9F EB D3',
         '01-02 03:04 05 ab',
+        '0102.03:04.05ab',
       ],
     });
   });


### PR DESCRIPTION
Network devices like cisco or arista switches use mac address dot notion:

`0102.0304.05ab`

This allows it to be validated.