### PR TITLE
Give names to default exports (isLatLong & isPostalCode)

### DIFF
--- a/src/lib/isLatLong.js
+++ b/src/lib/isLatLong.js
@@ -3,7 +3,7 @@ import assertString from './util/assertString';
 const lat = /^\(?[+-]?(90(\.0+)?|[1-8]?\d(\.\d+)?)$/;
 const long = /^\s?[+-]?(180(\.0+)?|1[0-7]\d(\.\d+)?|\d{1,2}(\.\d+)?)\)?$/;
 
-export default function (str) {
+export default function isLatLong(str) {
   assertString(str);
   if (!str.includes(',')) return false;
   const pair = str.split(',');

--- a/src/lib/isPostalCode.js
+++ b/src/lib/isPostalCode.js
@@ -63,7 +63,7 @@ const patterns = {
 
 export const locales = Object.keys(patterns);
 
-export default function (str, locale) {
+export default function isPostalCode(str, locale) {
   assertString(str);
   if (locale in patterns) {
     return patterns[locale].test(str);


### PR DESCRIPTION
👋 My use case requires default exports to be named and relates to https://github.com/validatorjs/validator.js/issues/1264. I only found 2 in your codebase (`isLatLong` and `isPostalCode`) that didn't have names for their default exports, so I'm updating just those two in `src/lib/`

Some benefits of naming exports:

* Functions get a `name`
* Easier to debug
* You're already doing it for the rest of your functions minus these two

I have no idea why `npm run test` built all these additional files (let me know if I did something wrong and how I can fix it)

Hope this is a helpful improvement.

Thanks!