### PR TITLE
Fix: isCurrency symbol validator regex

### DIFF
--- a/src/lib/isCurrency.js
+++ b/src/lib/isCurrency.js
@@ -4,8 +4,9 @@ import assertString from './util/assertString';
 function currencyRegex(options) {
   let decimal_digits = `\\d{${options.digits_after_decimal[0]}}`;
   options.digits_after_decimal.forEach((digit, index) => { if (index !== 0) decimal_digits = `${decimal_digits}|\\d{${digit}}`; });
+
   const symbol =
-    `(\\${options.symbol.replace(/\./g, '\\.')})${(options.require_symbol ? '' : '?')}`,
+    `(${options.symbol.replace(/\W/, m => `\\${m}`)})${(options.require_symbol ? '' : '?')}`,
     negative = '-?',
     whole_dollar_amount_without_sep = '[1-9]\\d*',
     whole_dollar_amount_with_sep = `[1-9]\\d{0,2}(\\${options.thousands_separator}\\d{3})*`,

--- a/test/validators.js
+++ b/test/validators.js
@@ -7293,7 +7293,6 @@ describe('Validators', () => {
         '(-$)',
       ],
     });
-
     // $##,###.## with no negatives (en-US, en-CA, en-AU, en-HK)
     test({
       validator: 'isCurrency',
@@ -7346,6 +7345,29 @@ describe('Validators', () => {
         '',
         '- $',
         '-$10,123.45',
+      ],
+    });
+
+    //  R$ ##,###.## (pt_BR)
+    test({
+      validator: 'isCurrency',
+      args: [
+        {
+          symbol: 'R$',
+          require_symbol: true,
+          allow_space_after_symbol: true,
+          symbol_after_digits: false,
+          thousands_separator: '.',
+          decimal_separator: ',',
+        },
+      ],
+      valid: [
+        'R$ 1.400,00',
+        'R$ 400,00',
+      ],
+      invalid: [
+        '$ 1.400,00',
+        '$R 1.400,00',
       ],
     });
   });


### PR DESCRIPTION
Some of the currency symbols starts with letters. For example: 
- Brazil Real R$
- Dominican Republic Peso RD$ 

For those cases, the RegExp pattern created to validate the currency simbol is not valid: 


Generated regex: 
```
 -?(\R$) ?(0|[1-9]\d*|[1-9]\d{0,2}(\,\d{3})*)?(\.(\d{2}))?
```
Expected regex:
```
-?(R\$) ?(0|[1-9]\d*|[1-9]\d{0,2}(\.\d{3})*)?(\,(\d{2}))?
```

Resolves #1292