### PR TITLE
Fix Space Error in isSlug()

### DIFF
--- a/src/lib/isSlug.js
+++ b/src/lib/isSlug.js
@@ -1,6 +1,6 @@
 import assertString from './util/assertString';
 
-let charsetRegex = /^[^-_](?!.*?[-_]{2,})([a-z0-9\\-]{1,}).*[^-_]$/;
+let charsetRegex = /^[^\s-_](?!.*?[-_]{2,})([a-z0-9-\\]{1,})[^\s]*[^-_\s]$/;
 
 export default function isSlug(str) {
   assertString(str);

--- a/test/validators.js
+++ b/test/validators.js
@@ -8369,6 +8369,7 @@ describe('Validators', () => {
         'not-slug-',
         '_not-slug',
         'not-slug_',
+        'not slug',
       ],
     });
   });


### PR DESCRIPTION
Issue #1287 

feat(isSlug): Fixed the problem in which isSlug() was also returning `true` for slugs with spaces for e.g. `not a-slug`.

I created a regex which will reject the slug while testing if it has spaces in the beginning, in the middle or at the end and has replaced my regex with the current one.
