### PR TITLE
chore(build): add node 6 on build pipeline

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ node_js:
   - 10
   - 9
   - 8
+  - 6
 notifications:
   email: false
 after_script:


### PR DESCRIPTION
Adding Node v6 on the build pipeline to act as a proxy for "old" browsers.

<!--
Add a descriptive title textbox above, e.g.
feat(validatorName): brief title of what has been done
-->


## Checklist

- [x] PR contains only changes related; no stray files, etc.
- [x] README updated (where applicable)
- [ ] Tests written (where applicable)
