### PR TITLE
Refactor isTaxID for supporting more locales

### DIFF
--- a/src/lib/isTaxID.js
+++ b/src/lib/isTaxID.js
@@ -1,6 +1,8 @@
 import assertString from './util/assertString';
 
 /**
+ * en-US TIN Validation
+ *
  * An Employer Identification Number (EIN), also known as a Federal Tax Identification Number,
  *  is used to identify a business entity.
  *
@@ -13,46 +15,46 @@ import assertString from './util/assertString';
  */
 
 
-/**
- * Campus prefixes according to locales
- */
-
-const campusPrefix = {
-  'en-US': {
-    andover: ['10', '12'],
-    atlanta: ['60', '67'],
-    austin: ['50', '53'],
-    brookhaven: ['01', '02', '03', '04', '05', '06', '11', '13', '14', '16', '21', '22', '23', '25', '34', '51', '52', '54', '55', '56', '57', '58', '59', '65'],
-    cincinnati: ['30', '32', '35', '36', '37', '38', '61'],
-    fresno: ['15', '24'],
-    internet: ['20', '26', '27', '45', '46', '47'],
-    kansas: ['40', '44'],
-    memphis: ['94', '95'],
-    ogden: ['80', '90'],
-    philadelphia: ['33', '39', '41', '42', '43', '46', '48', '62', '63', '64', '66', '68', '71', '72', '73', '74', '75', '76', '77', '81', '82', '83', '84', '85', '86', '87', '88', '91', '92', '93', '98', '99'],
-    sba: ['31'],
-  },
+// Valid US IRS campus prefixes
+const enUsCampusPrefix = {
+  andover: ['10', '12'],
+  atlanta: ['60', '67'],
+  austin: ['50', '53'],
+  brookhaven: ['01', '02', '03', '04', '05', '06', '11', '13', '14', '16', '21', '22', '23', '25', '34', '51', '52', '54', '55', '56', '57', '58', '59', '65'],
+  cincinnati: ['30', '32', '35', '36', '37', '38', '61'],
+  fresno: ['15', '24'],
+  internet: ['20', '26', '27', '45', '46', '47'],
+  kansas: ['40', '44'],
+  memphis: ['94', '95'],
+  ogden: ['80', '90'],
+  philadelphia: ['33', '39', '41', '42', '43', '46', '48', '62', '63', '64', '66', '68', '71', '72', '73', '74', '75', '76', '77', '81', '82', '83', '84', '85', '86', '87', '88', '91', '92', '93', '98', '99'],
+  sba: ['31'],
 };
 
-
-function getPrefixes(locale) {
+// Return an array of all US IRS campus prefixes
+function enUsGetPrefixes() {
   const prefixes = [];
 
-  for (const location in campusPrefix[locale]) {
+  for (const location in enUsCampusPrefix) {
     // https://github.com/gotwarlost/istanbul/blob/master/ignoring-code-for-coverage.md#ignoring-code-for-coverage-purposes
     // istanbul ignore else
-    if (campusPrefix[locale].hasOwnProperty(location)) {
-      prefixes.push(...campusPrefix[locale][location]);
+    if (enUsCampusPrefix.hasOwnProperty(location)) {
+      prefixes.push(...enUsCampusPrefix[location]);
     }
   }
-
-  prefixes.sort();
 
   return prefixes;
 }
 
-// tax id regex formats for various locales
+/*
+ * en-US validation function
+ * Verify that the TIN starts with a valid IRS campus prefix
+ */
+function enUsCheck(tin) {
+  return enUsGetPrefixes().indexOf(tin.substr(0, 2)) !== -1;
+}
 
+// tax id regex formats for various locales
 const taxIdFormat = {
 
   'en-US': /^\d{2}[- ]{0,1}\d{7}$/,
@@ -60,14 +62,31 @@ const taxIdFormat = {
 };
 
 
+// Algorithmic tax id check functions for various locales
+const taxIdCheck = {
+
+  'en-US': enUsCheck,
+
+};
+
+/*
+ * Validator function
+ * Return true if the passed string is a valid tax identification number
+ * for the specified locale.
+ * Throw an error exception if the locale is not supported.
+ */
 export default function isTaxID(str, locale = 'en-US') {
   assertString(str);
   if (locale in taxIdFormat) {
     if (!taxIdFormat[locale].test(str)) {
       return false;
     }
-    return getPrefixes(locale).indexOf(str.substr(0, 2)) !== -1;
+
+    if (locale in taxIdCheck) {
+      return taxIdCheck[locale](str);
+    }
+    // Fallthrough; not all locales have algorithmic checks
+    return true;
   }
   throw new Error(`Invalid locale '${locale}'`);
 }
-


### PR DESCRIPTION
* Prefix US-related functionality with "enUs"
* Remove assumption of global IRS-like campus prefixes
* Move US prefix check into separate function
* Add per-locale check function lookup table
* Support future locales lacking a check function (e.g. UK)
* Remove unneeded sorting of the IRS campus prefixes
* Add comments

## Checklist

- [x] PR contains only changes related; no stray files, etc.
- [x] README updated (where applicable)
- [x] Tests written (where applicable)
