### PR TITLE
fix isBase64 and isBase32 seeing empty string as invalid, fixes #1418

### DIFF
--- a/src/lib/isBase32.js
+++ b/src/lib/isBase32.js
@@ -5,7 +5,7 @@ const base32 = /^[A-Z2-7]+=*$/;
 export default function isBase32(str) {
   assertString(str);
   const len = str.length;
-  if (len > 0 && len % 8 === 0 && base32.test(str)) {
+  if (len % 8 === 0 && base32.test(str)) {
     return true;
   }
   return false;

--- a/src/lib/isBase64.js
+++ b/src/lib/isBase64.js
@@ -2,7 +2,7 @@ import assertString from './util/assertString';
 import merge from './util/merge';
 
 const notBase64 = /[^A-Z0-9+\/=]/i;
-const urlSafeBase64 = /^[A-Z0-9_\-]+$/i;
+const urlSafeBase64 = /^[A-Z0-9_\-]*$/i;
 
 const defaultBase64Options = {
   urlSafe: false,
@@ -17,7 +17,7 @@ export default function isBase64(str, options) {
     return urlSafeBase64.test(str);
   }
 
-  if (!len || len % 4 !== 0 || notBase64.test(str)) {
+  if (len % 4 !== 0 || notBase64.test(str)) {
     return false;
   }
 

--- a/test/validators.js
+++ b/test/validators.js
@@ -4733,6 +4733,7 @@ describe('Validators', () => {
     test({
       validator: 'isBase64',
       valid: [
+        '',
         'Zg==',
         'Zm8=',
         'Zm9v',
@@ -4752,7 +4753,6 @@ describe('Validators', () => {
       ],
       invalid: [
         '12345',
-        '',
         'Vml2YW11cyBmZXJtZtesting123',
         'Zg=',
         'Z===',
@@ -4766,6 +4766,7 @@ describe('Validators', () => {
       validator: 'isBase64',
       args: [{ urlSafe: true }],
       valid: [
+        '',
         'bGFkaWVzIGFuZCBnZW50bGVtZW4sIHdlIGFyZSBmbG9hdGluZyBpbiBzcGFjZQ',
         '1234',
         'bXVtLW5ldmVyLXByb3Vk',
@@ -4776,7 +4777,6 @@ describe('Validators', () => {
         ' AA',
         '\tAA',
         '\rAA',
-        '',
         '\nAA',
         'This+isa/bad+base64Url==',
         '0K3RgtC+INC30LDQutC+0LTQuNGA0L7QstCw0L3QvdCw0Y8g0YHRgtGA0L7QutCw',
@@ -8717,6 +8717,7 @@ describe('Validators', () => {
       validator: 'isBase64',
       args: [{ urlSafe: true }],
       valid: [
+        '',
         'bGFkaWVzIGFuZCBnZW50bGVtZW4sIHdlIGFyZSBmbG9hdGluZyBpbiBzcGFjZQ',
         '1234',
         'bXVtLW5ldmVyLXByb3Vk',
@@ -8729,7 +8730,6 @@ describe('Validators', () => {
         '\rAA',
         '\nAA',
         '123=',
-        '',
         'This+isa/bad+base64Url==',
         '0K3RgtC+INC30LDQutC+0LTQuNGA0L7QstCw0L3QvdCw0Y8g0YHRgtGA0L7QutCw',
       ],


### PR DESCRIPTION
<!--
Add a descriptive title textbox above, e.g.
feat(validatorName): brief title of what has been done
-->

isBase64('') and isBase32('') now return true, which is correct behaviour according to [RFC4648](https://tools.ietf.org/html/rfc4648#section-10)

Upon regeneration of the code, there were some additional files changes, I am not sure if this is right, so I made a seperate commit.

## Checklist

- [ ] PR contains only changes related; no stray files, etc.
- [x] README updated (where applicable)
- [x] Tests written (where applicable)
