### PR TITLE
docs: Fix simple typo, preffered -> preferred

### DIFF
--- a/es/lib/normalizeEmail.js
+++ b/es/lib/normalizeEmail.js
@@ -128,7 +128,7 @@ export default function normalizeEmail(email, options) {
       parts[0] = parts[0].toLowerCase();
     }
 
-    parts[1] = 'yandex.ru'; // all yandex domains are equal, 1st preffered
+    parts[1] = 'yandex.ru'; // all yandex domains are equal, 1st preferred
   } else if (options.all_lowercase) {
     // Any other address
     parts[0] = parts[0].toLowerCase();

--- a/lib/normalizeEmail.js
+++ b/lib/normalizeEmail.js
@@ -138,7 +138,7 @@ function normalizeEmail(email, options) {
       parts[0] = parts[0].toLowerCase();
     }
 
-    parts[1] = 'yandex.ru'; // all yandex domains are equal, 1st preffered
+    parts[1] = 'yandex.ru'; // all yandex domains are equal, 1st preferred
   } else if (options.all_lowercase) {
     // Any other address
     parts[0] = parts[0].toLowerCase();

--- a/src/lib/normalizeEmail.js
+++ b/src/lib/normalizeEmail.js
@@ -232,7 +232,7 @@ export default function normalizeEmail(email, options) {
     if (options.all_lowercase || options.yandex_lowercase) {
       parts[0] = parts[0].toLowerCase();
     }
-    parts[1] = 'yandex.ru'; // all yandex domains are equal, 1st preffered
+    parts[1] = 'yandex.ru'; // all yandex domains are equal, 1st preferred
   } else if (options.all_lowercase) {
     // Any other address
     parts[0] = parts[0].toLowerCase();

--- a/validator.js
+++ b/validator.js
@@ -2954,7 +2954,7 @@ function normalizeEmail(email, options) {
       parts[0] = parts[0].toLowerCase();
     }
 
-    parts[1] = 'yandex.ru'; // all yandex domains are equal, 1st preffered
+    parts[1] = 'yandex.ru'; // all yandex domains are equal, 1st preferred
   } else if (options.all_lowercase) {
     // Any other address
     parts[0] = parts[0].toLowerCase();


### PR DESCRIPTION
There is a small typo in es/lib/normalizeEmail.js, lib/normalizeEmail.js, src/lib/normalizeEmail.js, validator.js.

Should read `preferred` rather than `preffered`.

