### PR TITLE
Do not validate the length of email parts if ignore_max_length is true

### DIFF
--- a/src/lib/isEmail.js
+++ b/src/lib/isEmail.js
@@ -10,6 +10,7 @@ const default_email_options = {
   require_display_name: false,
   allow_utf8_local_part: true,
   require_tld: true,
+  ignore_max_length: false,
 };
 
 /* eslint-disable max-len */
@@ -118,8 +119,10 @@ export default function isEmail(str, options) {
     }
   }
 
-  if (!isByteLength(user, { max: 64 }) ||
-            !isByteLength(domain, { max: 254 })) {
+  if (options.ignore_max_length === false && (
+    !isByteLength(user, { max: 64 }) ||
+    !isByteLength(domain, { max: 254 }))
+  ) {
     return false;
   }
 

--- a/test/validators.js
+++ b/test/validators.js
@@ -301,7 +301,7 @@ describe('Validators', () => {
       args: [{ ignore_max_length: false }],
       valid: [],
       invalid: [
-        'Deleted-user-id-19430-Team-5051deleted-user-id-19430-team-5051XXXXXX@example.com'
+        'Deleted-user-id-19430-Team-5051deleted-user-id-19430-team-5051XXXXXX@example.com',
       ],
     });
 

--- a/test/validators.js
+++ b/test/validators.js
@@ -295,6 +295,26 @@ describe('Validators', () => {
     });
   });
 
+  it('should validate really long emails if ignore_max_length is set', () => {
+    test({
+      validator: 'isEmail',
+      args: [{ ignore_max_length: false }],
+      valid: [],
+      invalid: [
+        'Deleted-user-id-19430-Team-5051deleted-user-id-19430-team-5051XXXXXX@example.com'
+      ],
+    });
+
+    test({
+      validator: 'isEmail',
+      args: [{ ignore_max_length: true }],
+      valid: [
+        'Deleted-user-id-19430-Team-5051deleted-user-id-19430-team-5051XXXXXX@example.com',
+      ],
+      invalid: [],
+    });
+  });
+
   it('should validate URLs', () => {
     test({
       validator: 'isURL',


### PR DESCRIPTION
This PR skips the special validation of the domain and user if `ignore_max_length` is set to true.  The README already implies this behavior is happening:

>  If ignore_max_length is set to true, the validator will not check for the standard max length of an email.

Closes https://github.com/validatorjs/validator.js/issues/1434

## Checklist

- [x] PR contains only changes related; no stray files, etc.
- [x] README updated (where applicable)
- [x] Tests written (where applicable)
