### PR TITLE
Faster, more readable, less nested and consistent assertString function

### DIFF
--- a/src/lib/util/assertString.js
+++ b/src/lib/util/assertString.js
@@ -6,6 +6,6 @@ export default function assertString(input) {
     if (input === null) invalidType = 'null';
     else if (invalidType === 'object') invalidType = input.constructor.name;
 
-    throw new TypeError(`Expected a string but received a ${invalidType}`);
+    throw new Error(`Expected a string but received a ${invalidType}`);
   }
 }

--- a/src/lib/util/assertString.js
+++ b/src/lib/util/assertString.js
@@ -2,17 +2,10 @@ export default function assertString(input) {
   const isString = (typeof input === 'string' || input instanceof String);
 
   if (!isString) {
-    let invalidType;
-    if (input === null) {
-      invalidType = 'null';
-    } else {
-      invalidType = typeof input;
-      if (invalidType === 'object' && input.constructor && input.constructor.hasOwnProperty('name')) {
-        invalidType = input.constructor.name;
-      } else {
-        invalidType = `a ${invalidType}`;
-      }
-    }
-    throw new TypeError(`Expected string but received ${invalidType}.`);
+    let invalidType = typeof input;
+    if (input === null) invalidType = 'null';
+    else if (invalidType === 'object') invalidType = input.constructor.name;
+
+    throw new TypeError(`Expected a string but received a ${invalidType}`);
   }
 }


### PR DESCRIPTION
I have updated the assertString utility function in src/lib/util/assertString.js.
The new function is **more readable** and has **less nesting**. It has less if/else nesting and also has a **consistent error message** (previously some error messages have "... received a [invalidType]" and some of them have "... received [invalidType]", now it is always "... received a [invalidType]").
I measured performances of the current function and the new function, it's a small margin but the new function is **faster by 0.006 to 0.01 milliseconds** on an average.
![image](https://user-images.githubusercontent.com/54456279/94898522-55311500-04af-11eb-91e4-e4c09959aa64.png)
![image](https://user-images.githubusercontent.com/54456279/94898566-667a2180-04af-11eb-9535-0d07741f1fb7.png)
![image](https://user-images.githubusercontent.com/54456279/94898606-73971080-04af-11eb-990e-70b934f5ef38.png)
