### PR TITLE
fix(isFQDN): allow all-underscore labels with allow_underscores (#1253)

### DIFF
--- a/src/lib/isFQDN.js
+++ b/src/lib/isFQDN.js
@@ -37,10 +37,7 @@ export default function isFQDN(str, options) {
     if (!options.allow_numeric_tld && i === parts.length - 1 && /^\d+$/.test(part)) {
       return false; // reject numeric TLDs
     }
-    if (options.allow_underscores) {
-      part = part.replace(/_/g, '');
-    }
-    if (!/^[a-z\u00a1-\uffff0-9-]+$/i.test(part)) {
+    if (!/^[a-z_\u00a1-\uffff0-9-]+$/i.test(part)) {
       return false;
     }
     // disallow full-width chars
@@ -48,6 +45,9 @@ export default function isFQDN(str, options) {
       return false;
     }
     if (part[0] === '-' || part[part.length - 1] === '-') {
+      return false;
+    }
+    if (!options.allow_underscores && /_/.test(part)) {
       return false;
     }
   }

--- a/test/validators.js
+++ b/test/validators.js
@@ -481,6 +481,7 @@ describe('Validators', () => {
         'http://foo_bar.com',
         'http://pr.example_com.294.example.com/',
         'http://foo__bar.com',
+        'http://_.example.com',
       ],
       invalid: [],
     });


### PR DESCRIPTION
Update `isFQDN` to allow domain names with all-underscore labels when `allow_underscores` is true. Underscore is not allowed in LDH "preferred name syntax" host names, but may appear anywhere in generic domain name labels (cf. [RFC 8499](https://tools.ietf.org/html/rfc8499#page-8)).

## Checklist

- [x] PR contains only changes related; no stray files, etc.
- [ ] ~~README updated (where applicable)~~
- [x] Tests written (where applicable)
