### PR TITLE
chore: update assert.equal() to assert.strictEqual()

### DIFF
--- a/test/client-side.js
+++ b/test/client-side.js
@@ -6,7 +6,7 @@ describe('Minified version', () => {
   it('should export the same things as the server-side version', () => {
     for (let key in validator) {
       if ({}.hasOwnProperty.call(validator, key)) {
-        assert.equal(
+        assert.strictEqual(
           typeof validator[key],
           typeof min[key], `Minified version did not export ${key}`
         );
@@ -15,15 +15,15 @@ describe('Minified version', () => {
   });
 
   it('should be up to date', () => {
-    assert.equal(min.version, validator.version, 'Minified version mismatch. Run `make min`');
+    assert.strictEqual(min.version, validator.version, 'Minified version mismatch. Run `make min`');
   });
 
   it('should validate strings', () => {
-    assert.equal(min.isEmail('foo@bar.com'), true);
-    assert.equal(min.isEmail('foo'), false);
+    assert.strictEqual(min.isEmail('foo@bar.com'), true);
+    assert.strictEqual(min.isEmail('foo'), false);
   });
 
   it('should sanitize strings', () => {
-    assert.equal(min.toBoolean('1'), true);
+    assert.strictEqual(min.toBoolean('1'), true);
   });
 });

--- a/test/exports.js
+++ b/test/exports.js
@@ -8,18 +8,18 @@ import { locales as isFloatLocales } from '../src/lib/isFloat';
 
 describe('Exports', () => {
   it('should export validators', () => {
-    assert.equal(typeof validator.isEmail, 'function');
-    assert.equal(typeof validator.isAlpha, 'function');
+    assert.strictEqual(typeof validator.isEmail, 'function');
+    assert.strictEqual(typeof validator.isAlpha, 'function');
   });
 
   it('should export sanitizers', () => {
-    assert.equal(typeof validator.toBoolean, 'function');
-    assert.equal(typeof validator.toFloat, 'function');
+    assert.strictEqual(typeof validator.toBoolean, 'function');
+    assert.strictEqual(typeof validator.toFloat, 'function');
   });
 
   it('should export the version number', () => {
     /* eslint-disable global-require */
-    assert.equal(
+    assert.strictEqual(
       validator.version, require('../package.json').version,
       'Version number mismatch in "package.json" vs. "validator.js"'
     );

--- a/test/validators.js
+++ b/test/validators.js
@@ -4940,14 +4940,14 @@ describe('Validators', () => {
 
     let sandbox = vm.createContext(window);
     vm.runInContext(validator_js, sandbox);
-    assert.equal(window.validator.trim('  foobar '), 'foobar');
+    assert.strictEqual(window.validator.trim('  foobar '), 'foobar');
   });
 
   it('should bind validator to the window if no module loaders are available', () => {
     let window = {};
     let sandbox = vm.createContext(window);
     vm.runInContext(validator_js, sandbox);
-    assert.equal(window.validator.trim('  foobar '), 'foobar');
+    assert.strictEqual(window.validator.trim('  foobar '), 'foobar');
   });
 
   it('should validate mobile phone number', () => {


### PR DESCRIPTION
<!--
Add a descriptive title textbox above, e.g.
feat(validatorName): brief title of what has been done
-->

Hi, just a quick fix. IDE was showing errors, it looks like `assert.equal()` was deprecated.
https://nodejs.org/api/assert.html#assert_assert_equal_actual_expected_message

<img width="697" alt="Screen Shot 2020-10-06 at 3 05 45 PM" src="https://user-images.githubusercontent.com/3595986/95275948-baae3a00-07fe-11eb-8810-c77ae21f87b2.png">

## Checklist

- [x] PR contains only changes related; no stray files, etc.
- [x] README updated (where applicable)
- [x] Tests written (where applicable)
