### PR TITLE
fixed lib in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,4 @@ coverage.lcov
 package-lock.json
 yarn.lock
 es
-lib
+lib/*

--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,5 @@ coverage.lcov
 .nyc_output
 package-lock.json
 yarn.lock
-es
-lib/*
+/es
+/lib


### PR DESCRIPTION
So in my previous pr for excluding build files, I had added `lib` to `gitgnore`, turns out doing that also removes the tracking of files under `src/lib`. This PR fixes that

## Checklist

- [x] PR contains only changes related; no stray files, etc.
- [ ] README updated (where applicable)
- [ ] Tests written (where applicable)
