### PR TITLE
Refactor merge.js to be a simple one line

### DIFF
--- a/src/lib/util/merge.js
+++ b/src/lib/util/merge.js
@@ -1,8 +1,3 @@
 export default function merge(obj = { }, defaults) {
-  for (const key in defaults) {
-    if (typeof obj[key] === 'undefined') {
-      obj[key] = defaults[key];
-    }
-  }
-  return obj;
+  return { ...defaults, ...obj };
 }


### PR DESCRIPTION
I refactored utils/merge.js to be a one liner function that uses ES6 spread operator to merge objects.
All tests have been run successfully after the new change.