### PR TITLE
feat(isLicensePlate): adding license plate validators for 'mercosur' and 'pt-BR' locales

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Validator                               | Description
 **isJWT(str)**                         | check if the string is valid JWT token.
 **isLatLong(str [, options])**                      | check if the string is a valid latitude-longitude coordinate in the format `lat,long` or `lat, long`.<br/><br/>`options` is an object that defaults to `{ checkDMS: false }`. Pass `checkDMS` as `true` to validate DMS(degrees, minutes, and seconds) latitude-longitude format. 
 **isLength(str [, options])**              | check if the string's length falls in a range.<br/><br/>`options` is an object which defaults to `{min:0, max: undefined}`. Note: this function takes into account surrogate pairs.
-**isLicensePlate(str [, locale])**     | check if string matches the format of a country's license plate.<br/><br/>(locale is one of `['de-DE', 'de-LI', 'pt-PT', 'sq-AL', 'pt-BR', 'mercosur']` or `any`). 
+**isLicensePlate(str [, locale])**     | check if string matches the format of a country's license plate.<br/><br/>(locale is one of `['de-DE', 'de-LI', 'pt-PT', 'sq-AL', 'pt-BR'']` or `any`). 
 **isLocale(str)**                       | check if the string is a locale
 **isLowercase(str)**                    | check if the string is lowercase.
 **isMACAddress(str)**                   | check if the string is a MAC address.<br/><br/>`options` is an object which defaults to `{no_colons: false}`. If `no_colons` is true, the validator will allow MAC addresses without the colons. Also, it allows the use of hyphens, spaces or dots e.g  '01 02 03 04 05 ab', '01-02-03-04-05-ab' or '0102.0304.05ab'.

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Validator                               | Description
 **isJWT(str)**                         | check if the string is valid JWT token.
 **isLatLong(str [, options])**                      | check if the string is a valid latitude-longitude coordinate in the format `lat,long` or `lat, long`.<br/><br/>`options` is an object that defaults to `{ checkDMS: false }`. Pass `checkDMS` as `true` to validate DMS(degrees, minutes, and seconds) latitude-longitude format. 
 **isLength(str [, options])**              | check if the string's length falls in a range.<br/><br/>`options` is an object which defaults to `{min:0, max: undefined}`. Note: this function takes into account surrogate pairs.
-**isLicensePlate(str [, locale])**     | check if string matches the format of a country's license plate.<br/><br/>(locale is one of `['de-DE', 'de-LI', 'pt-PT', 'sq-AL']` or `any`)
+**isLicensePlate(str [, locale])**     | check if string matches the format of a country's license plate.<br/><br/>(locale is one of `['de-DE', 'de-LI', 'pt-PT', 'sq-AL', 'pt-BR', 'mercosur']` or `any`). 
 **isLocale(str)**                       | check if the string is a locale
 **isLowercase(str)**                    | check if the string is lowercase.
 **isMACAddress(str)**                   | check if the string is a MAC address.<br/><br/>`options` is an object which defaults to `{no_colons: false}`. If `no_colons` is true, the validator will allow MAC addresses without the colons. Also, it allows the use of hyphens, spaces or dots e.g  '01 02 03 04 05 ab', '01-02-03-04-05-ab' or '0102.0304.05ab'.

--- a/src/lib/isLicensePlate.js
+++ b/src/lib/isLicensePlate.js
@@ -8,6 +8,10 @@ const validators = {
     /^([A-Z]{2}|[0-9]{2})[ -·]?([A-Z]{2}|[0-9]{2})[ -·]?([A-Z]{2}|[0-9]{2})$/.test(str),
   'sq-AL': str =>
     /^[A-Z]{2}[- ]?((\d{3}[- ]?(([A-Z]{2})|T))|(R[- ]?\d{3}))$/.test(str),
+  'pt-BR': str =>
+    /^[A-Z]{3}[ -]?[0-9][A-Z][0-9]{2}|[A-Z]{3}[ -]?[0-9]{4}$/.test(str),
+  mercosur: str =>
+    /^[A-Z]{2}[ -]?[0-9]{3}[ -]?[A-Z]{2}|[A-Z]{3}[ -]?[0-9][A-Z][0-9]{2}|[A-Z]{4}[ -]?[0-9]{3}|[A-Z]{3}[ -]?[0-9]{4}$/.test(str),
 };
 
 export default function isLicensePlate(str, locale) {

--- a/src/lib/isLicensePlate.js
+++ b/src/lib/isLicensePlate.js
@@ -10,8 +10,6 @@ const validators = {
     /^[A-Z]{2}[- ]?((\d{3}[- ]?(([A-Z]{2})|T))|(R[- ]?\d{3}))$/.test(str),
   'pt-BR': str =>
     /^[A-Z]{3}[ -]?[0-9][A-Z][0-9]{2}|[A-Z]{3}[ -]?[0-9]{4}$/.test(str),
-  mercosur: str =>
-    /^[A-Z]{2}[ -]?[0-9]{3}[ -]?[A-Z]{2}|[A-Z]{3}[ -]?[0-9][A-Z][0-9]{2}|[A-Z]{4}[ -]?[0-9]{3}|[A-Z]{3}[ -]?[0-9]{4}$/.test(str),
 };
 
 export default function isLicensePlate(str, locale) {

--- a/test/validators.js
+++ b/test/validators.js
@@ -10294,6 +10294,56 @@ describe('Validators', () => {
     });
     test({
       validator: 'isLicensePlate',
+      args: ['pt-BR'],
+      valid: [
+        'ABC1234',
+        'ABC 1234',
+        'ABC-1234',
+        'ABC1D23',
+        'ABC1K23',
+        'ABC1Z23',
+        'ABC 1D23',
+        'ABC-1D23',
+      ],
+      invalid: [
+        '',
+        'AA 0 A',
+        'AAA 00 AAA',
+        'ABCD123',
+        'AB12345',
+        'AB123DC',
+      ],
+    });
+    test({
+      validator: 'isLicensePlate',
+      args: ['mercosur'],
+      valid: [
+        'AB 123 CD',
+        'ABC 1A23',
+        'ABCD 123',
+        'ABC 1234',
+        'AB-123-CD',
+        'ABC-1A23',
+        'ABCD-123',
+        'ABC-1234',
+        'AB123CD',
+        'ABC1A23',
+        'ABCD123',
+        'ABC1234',
+      ],
+      invalid: [
+        '',
+        'A0A0A0A0',
+        ' A A00 ',
+        '0101PTQ',
+        '01PTQPQ',
+        'A1 A23 CD',
+        'AB1 AA23',
+        'ABCDE 23',
+      ],
+    });
+    test({
+      validator: 'isLicensePlate',
       args: ['any'],
       valid: [
         'FL 1',

--- a/test/validators.js
+++ b/test/validators.js
@@ -10316,34 +10316,6 @@ describe('Validators', () => {
     });
     test({
       validator: 'isLicensePlate',
-      args: ['mercosur'],
-      valid: [
-        'AB 123 CD',
-        'ABC 1A23',
-        'ABCD 123',
-        'ABC 1234',
-        'AB-123-CD',
-        'ABC-1A23',
-        'ABCD-123',
-        'ABC-1234',
-        'AB123CD',
-        'ABC1A23',
-        'ABCD123',
-        'ABC1234',
-      ],
-      invalid: [
-        '',
-        'A0A0A0A0',
-        ' A A00 ',
-        '0101PTQ',
-        '01PTQPQ',
-        'A1 A23 CD',
-        'AB1 AA23',
-        'ABCDE 23',
-      ],
-    });
-    test({
-      validator: 'isLicensePlate',
       args: ['any'],
       valid: [
         'FL 1',


### PR DESCRIPTION
Update 2021-03-08: removing `mercosur` as per the discussion.

Adding 2 new validators for license plates:

- `pt-BR`: Brazil is in transition from legacy format to Mercosur format, with it's own format rules. This validator accepts both legacy and new formats for Brazil;
  - https://pt.wikipedia.org/wiki/Placas_de_identifica%C3%A7%C3%A3o_de_ve%C3%ADculos_no_Mercosul#_Brasil
- `mercosur`: New rules for Argentina, Brazil, Paraguay, Uruguay and Venezuela (currently suspended from Mercosur but plate format still applies).
  - https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_the_Mercosur

## Checklist

- [X] PR contains only changes related; no stray files, etc.
- [X] README updated (where applicable)
- [X] Tests written (where applicable)
