### PR TITLE
fix(isSlug & rtrim): regex no longer exposed to ReDOS attacks

### DIFF
--- a/src/lib/isSlug.js
+++ b/src/lib/isSlug.js
@@ -1,6 +1,6 @@
 import assertString from './util/assertString';
 
-let charsetRegex = /^[^\s-_](?!.*?[-_]{2,})([a-z0-9-\\]{1,})[^\s]*[^-_\s]$/;
+let charsetRegex = /^[^\s-_](?!.*?[-_]{2,})[a-z0-9-\\][^\s]*[^-_\s]$/;
 
 export default function isSlug(str) {
   assertString(str);

--- a/src/lib/rtrim.js
+++ b/src/lib/rtrim.js
@@ -3,6 +3,6 @@ import assertString from './util/assertString';
 export default function rtrim(str, chars) {
   assertString(str);
   // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#Escaping
-  const pattern = chars ? new RegExp(`[${chars.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}]+$`, 'g') : /\s+$/g;
+  const pattern = chars ? new RegExp(`[${chars.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}]+$`, 'g') : /(\s)+$/g;
   return str.replace(pattern, '');
 }


### PR DESCRIPTION
<!--
Add a descriptive title textbox above, e.g.
feat(validatorName): brief title of what has been done
-->
This should be merged after #1602 
Regexes are updated in order not to change their behaviour, but only their logic. 

Fixes #1596 and fixes #1599 

## Checklist

- [x] PR contains only changes related; no stray files, etc.
- [x] README updated (where applicable)
- [x] Tests written (where applicable)
