### PR TITLE
fix(isMacAddress): improve regexes and options

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Validator                               | Description
 **isLicensePlate(str [, locale])**     | check if string matches the format of a country's license plate.<br/><br/>(locale is one of `['de-DE', 'de-LI', 'pt-PT', 'sq-AL']` or `any`)
 **isLocale(str)**                       | check if the string is a locale
 **isLowercase(str)**                    | check if the string is lowercase.
-**isMACAddress(str)**                   | check if the string is a MAC address.<br/><br/>`options` is an object which defaults to `{no_colons: false}`. If `no_colons` is true, the validator will allow MAC addresses without the colons. Also, it allows the use of hyphens, spaces or dots e.g  '01 02 03 04 05 ab', '01-02-03-04-05-ab' or '0102.0304.05ab'.
+**isMACAddress(str)**                   | check if the string is a MAC address.<br/><br/>`options` is an object which defaults to `{noSeparators: false}`. If `noSeparators` is true, the validator will allow MAC addresses without separators. Also, it allows the use of hyphens, spaces or dots e.g  '01 02 03 04 05 ab', '01-02-03-04-05-ab' or '0102.0304.05ab'.
 **isMagnetURI(str)**                      | check if the string is a [magnet uri format](https://en.wikipedia.org/wiki/Magnet_URI_scheme).
 **isMD5(str)**                          | check if the string is a MD5 hash.<br/><br/>Please note that you can also use the `isHash(str, 'md5')` function. Keep in mind that MD5 has some collision weaknesses compared to other algorithms (e.g., SHA).
 **isMimeType(str)**                     | check if the string matches to a valid [MIME type](https://en.wikipedia.org/wiki/Media_type) format

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Validator                               | Description
 **isLicensePlate(str [, locale])**     | check if string matches the format of a country's license plate.<br/><br/>(locale is one of `['de-DE', 'de-LI', 'pt-PT', 'sq-AL']` or `any`)
 **isLocale(str)**                       | check if the string is a locale
 **isLowercase(str)**                    | check if the string is lowercase.
-**isMACAddress(str)**                   | check if the string is a MAC address.<br/><br/>`options` is an object which defaults to `{noSeparators: false}`. If `noSeparators` is true, the validator will allow MAC addresses without separators. Also, it allows the use of hyphens, spaces or dots e.g  '01 02 03 04 05 ab', '01-02-03-04-05-ab' or '0102.0304.05ab'.
+**isMACAddress(str)**                   | check if the string is a MAC address.<br/><br/>`options` is an object which defaults to `{no_separators: false}`. If `no_separators` is true, the validator will allow MAC addresses without separators. Also, it allows the use of hyphens, spaces or dots e.g  '01 02 03 04 05 ab', '01-02-03-04-05-ab' or '0102.0304.05ab'.
 **isMagnetURI(str)**                      | check if the string is a [magnet uri format](https://en.wikipedia.org/wiki/Magnet_URI_scheme).
 **isMD5(str)**                          | check if the string is a MD5 hash.<br/><br/>Please note that you can also use the `isHash(str, 'md5')` function. Keep in mind that MD5 has some collision weaknesses compared to other algorithms (e.g., SHA).
 **isMimeType(str)**                     | check if the string matches to a valid [MIME type](https://en.wikipedia.org/wiki/Media_type) format

--- a/src/lib/isMACAddress.js
+++ b/src/lib/isMACAddress.js
@@ -9,7 +9,7 @@ export default function isMACAddress(str, options) {
   /**
    * @deprecated `no_colons` deprecated
   */
-  if (options && (options.no_colons || options.noSeparators)) {
+  if (options && (options.no_colons || options.no_separators)) {
     return macAddressNoSeparators.test(str);
   }
 

--- a/src/lib/isMACAddress.js
+++ b/src/lib/isMACAddress.js
@@ -7,7 +7,7 @@ const macAddressWithDots = /^([0-9a-fA-F]{4}\.){2}([0-9a-fA-F]{4})$/;
 export default function isMACAddress(str, options) {
   assertString(str);
   /**
-   * @deprecated `no_colons` deprecated
+   * @deprecated `no_colons` TODO: remove it in the next major
   */
   if (options && (options.no_colons || options.no_separators)) {
     return macAddressNoSeparators.test(str);

--- a/src/lib/isMACAddress.js
+++ b/src/lib/isMACAddress.js
@@ -1,19 +1,18 @@
 import assertString from './util/assertString';
 
-const macAddress = /^([0-9a-fA-F][0-9a-fA-F]:){5}([0-9a-fA-F][0-9a-fA-F])$/;
-const macAddressNoColons = /^([0-9a-fA-F]){12}$/;
-const macAddressWithHyphen = /^([0-9a-fA-F][0-9a-fA-F]-){5}([0-9a-fA-F][0-9a-fA-F])$/;
-const macAddressWithSpaces = /^([0-9a-fA-F][0-9a-fA-F]\s){5}([0-9a-fA-F][0-9a-fA-F])$/;
-const macAddressWithDots = /^([0-9a-fA-F]{4}).([0-9a-fA-F]{4}).([0-9a-fA-F]{4})$/;
+const macAddress = /^(?:[0-9a-fA-F]{2}([-:\s]))([0-9a-fA-F]{2}\1){4}([0-9a-fA-F]{2})$/;
+const macAddressNoSeparator = /^([0-9a-fA-F]){12}$/;
+const macAddressWithDots = /^([0-9a-fA-F]{4}\.){2}([0-9a-fA-F]{4})$/;
 
 export default function isMACAddress(str, options) {
   assertString(str);
-  if (options && options.no_colons) {
-    return macAddressNoColons.test(str);
+  /**
+   * @deprecated `no_colons` deprecated
+  */
+  if (options && (options.no_colons || options.noSeparator)) {
+    return macAddressNoSeparator.test(str);
   }
 
   return macAddress.test(str)
-    || macAddressWithHyphen.test(str)
-    || macAddressWithSpaces.test(str)
     || macAddressWithDots.test(str);
 }

--- a/src/lib/isMACAddress.js
+++ b/src/lib/isMACAddress.js
@@ -1,7 +1,7 @@
 import assertString from './util/assertString';
 
 const macAddress = /^(?:[0-9a-fA-F]{2}([-:\s]))([0-9a-fA-F]{2}\1){4}([0-9a-fA-F]{2})$/;
-const macAddressNoSeparator = /^([0-9a-fA-F]){12}$/;
+const macAddressNoSeparators = /^([0-9a-fA-F]){12}$/;
 const macAddressWithDots = /^([0-9a-fA-F]{4}\.){2}([0-9a-fA-F]{4})$/;
 
 export default function isMACAddress(str, options) {
@@ -9,8 +9,8 @@ export default function isMACAddress(str, options) {
   /**
    * @deprecated `no_colons` deprecated
   */
-  if (options && (options.no_colons || options.noSeparator)) {
-    return macAddressNoSeparator.test(str);
+  if (options && (options.no_colons || options.noSeparators)) {
+    return macAddressNoSeparators.test(str);
   }
 
   return macAddress.test(str)

--- a/test/validators.js
+++ b/test/validators.js
@@ -719,21 +719,23 @@ describe('Validators', () => {
       invalid: [
         'abc',
         '01:02:03:04:05',
+        '01:02:03:04:05:z0',
         '01:02:03:04::ab',
         '1:2:3:4:5:6',
         'AB:CD:EF:GH:01:02',
         'A9C5 D4 9F EB D3',
         '01-02 03:04 05 ab',
         '0102.03:04.05ab',
+        '900f/dffs/sdea',
       ],
     });
   });
 
-  it('should validate MAC addresses without colons', () => {
+  it('should validate MAC addresses without separator', () => {
     test({
       validator: 'isMACAddress',
       args: [{
-        no_colons: true,
+        noSeparator: true,
       }],
       valid: [
         'abababababab',

--- a/test/validators.js
+++ b/test/validators.js
@@ -735,7 +735,7 @@ describe('Validators', () => {
     test({
       validator: 'isMACAddress',
       args: [{
-        noSeparator: true,
+        no_separators: true,
       }],
       valid: [
         'abababababab',


### PR DESCRIPTION
<!--
Add a descriptive title textbox above, e.g.
feat(validatorName): brief title of what has been done
-->
Fixes #1614 
This PR simplifies regexes, update the `no_colons` option name to `noSeparators`. Fixes `macAddressWithDots` regex to only allow dots as separator.
## Checklist

- [x] PR contains only changes related; no stray files, etc.
- [x] README updated (where applicable)
- [x] Tests written (where applicable)
