### PR TITLE
feat(validateAll): add validateAll function

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,8 @@ import toBoolean from './lib/toBoolean';
 import equals from './lib/equals';
 import contains from './lib/contains';
 import matches from './lib/matches';
+import validateAll from './lib/util/validateAll';
+
 
 import isEmail from './lib/isEmail';
 import isURL from './lib/isURL';
@@ -222,6 +224,7 @@ const validator = {
   isDate,
   isLicensePlate,
   isVAT,
+  validateAll,
 };
 
 export default validator;

--- a/src/lib/util/validateAll.js
+++ b/src/lib/util/validateAll.js
@@ -6,7 +6,7 @@ export default function validateAll(value, ...validatorFunctions) {
   const isValidatorFunctionsExist = validatorFunctions.length;
 
   if (!isValidatorFunctionsExist) {
-    throw new Error("validator functions can'nt be empty");
+    throw new Error("validator functions can't be empty");
   }
 
   for (let i = 0; i < validatorFunctions.length; i++) {

--- a/src/lib/util/validateAll.js
+++ b/src/lib/util/validateAll.js
@@ -1,0 +1,21 @@
+
+import assertString from './assertString';
+
+export default function validateAll(value, ...validatorFunctions) {
+  assertString(value);
+  const isValidatorFunctionsExist = validatorFunctions.length;
+
+  if (!isValidatorFunctionsExist) {
+    throw new Error("validator functions can'nt be empty");
+  }
+
+  for (let i = 0; i < validatorFunctions.length; i++) {
+    const currentValidatorFunction = validatorFunctions[i];
+    const isValid = currentValidatorFunction(value);
+    if (!isValid) {
+      return false;
+    }
+  }
+
+  return true;
+}


### PR DESCRIPTION
# ValidateAll()  function could take multiple validator and  exec with one value 

### example:
```javascript  
import isPort from 'validator/lib/isEmail';
import isAlphanumeric from 'validator/lib/isAlphanumeric';
import validateAll from 'validator/utils/validateAll'

validateAll('8080' ,isPort ,isAlphanumeric) // true
validateAll('a-80-2' ,isPort ,isAlphanumeric) // false 
```
## Checklist

- [x] PR contains only changes related; no stray files, etc.
- [ ] README updated (where applicable)
- [ ] Tests written (where applicable)
