### PR TITLE
Add typeof utility

### DIFF
--- a/src/lib/util/typeOf.js
+++ b/src/lib/util/typeOf.js
@@ -1,0 +1,10 @@
+/**
+ * Better way to handle type checking
+ * null, {}, array and date are objects, which confuses
+ */
+export default function typeOf(input) {
+  const rawObject = Object.prototype.toString.call(input).toLowerCase();
+  const typeOfRegex = /\[object (.*)]/g;
+  const type = typeOfRegex.exec(rawObject)[1];
+  return type;
+}

--- a/test/util.js
+++ b/test/util.js
@@ -1,0 +1,20 @@
+/**
+ * All tests that tests any utility.
+ * Prevent any breaking of functionality
+ */
+import assert from 'assert';
+import typeOf from '../src/lib/util/typeOf';
+
+describe('Util', () => {
+  it('should validate different typeOf', () => {
+    assert.strictEqual(typeOf([]), 'array');
+    assert.strictEqual(typeOf(null), 'null');
+    assert.strictEqual(typeOf({}), 'object');
+    assert.strictEqual(typeOf(new Date()), 'date');
+    assert.strictEqual(typeOf('ezkemboi'), 'string');
+    assert.strictEqual(typeOf(String('kemboi')), 'string');
+    assert.strictEqual(typeOf(undefined), 'undefined');
+    assert.strictEqual(typeOf(2021), 'number');
+    assert.notStrictEqual(typeOf([]), 'object');
+  });
+});


### PR DESCRIPTION
# What I have done
- Added type of utility to make sure it is easy to check the type of null, object, array, date, among others.
`I.e  type of {} == 'object' and type of null == 'null'` and not that all are `object`.
- Added tests for the same, as a way to protect any changes/breaking