### PR TITLE
feat(isBoolean) Add loose option to isBoolean validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Validator                               | Description
 **isBase64(str [, options])**          | check if a string is base64 encoded. options is optional and defaults to `{urlSafe: false}`<br/> when `urlSafe` is true it tests the given base64 encoded string is [url safe](https://base64.guru/standards/base64url)
 **isBefore(str [, date])**              | check if the string is a date that's before the specified date.
 **isBIC(str)**                          | check if a string is a BIC (Bank Identification Code) or SWIFT code.
-**isBoolean(str)**                      | check if a string is a boolean.
+**isBoolean(str [, options])**          | check if a string is a boolean.<br/>`options` is an object which defaults to `{ loose: false }`. If loose is is set to false, the validator will strictly match ['true', 'false', '0', '1']. If loose is set to true, the validator will also match 'yes', 'no', and will match a valid boolean string of any case. (eg: ['true', 'True', 'TRUE']).
 **isBtcAddress(str)**            | check if the string is a valid BTC address.
 **isByteLength(str [, options])**          | check if the string's length (in UTF-8 bytes) falls in a range.<br/><br/>`options` is an object which defaults to `{min:0, max: undefined}`.
 **isCreditCard(str)**                   | check if the string is a credit card.

--- a/src/lib/isBoolean.js
+++ b/src/lib/isBoolean.js
@@ -1,6 +1,16 @@
 import assertString from './util/assertString';
 
-export default function isBoolean(str) {
+const defaultOptions = { loose: false };
+
+export default function isBoolean(str, options = defaultOptions) {
   assertString(str);
-  return (['true', 'false', '1', '0'].indexOf(str) >= 0);
+
+  const strictBooleans = ['true', 'false', '1', '0'];
+  const looseBooleans = [...strictBooleans, 'yes', 'no'];
+
+  if (options.loose) {
+    return (looseBooleans.indexOf(str.toLowerCase()) >= 0);
+  }
+
+  return (strictBooleans.indexOf(str) >= 0);
 }

--- a/src/lib/isBoolean.js
+++ b/src/lib/isBoolean.js
@@ -1,16 +1,15 @@
 import assertString from './util/assertString';
 
 const defaultOptions = { loose: false };
+const strictBooleans = ['true', 'false', '1', '0'];
+const looseBooleans = [...strictBooleans, 'yes', 'no'];
 
 export default function isBoolean(str, options = defaultOptions) {
   assertString(str);
 
-  const strictBooleans = ['true', 'false', '1', '0'];
-  const looseBooleans = [...strictBooleans, 'yes', 'no'];
-
   if (options.loose) {
-    return (looseBooleans.indexOf(str.toLowerCase()) >= 0);
+    return looseBooleans.includes(str.toLowerCase());
   }
 
-  return (strictBooleans.indexOf(str) >= 0);
+  return strictBooleans.includes(str);
 }

--- a/test/validators.js
+++ b/test/validators.js
@@ -8870,6 +8870,37 @@ describe('Validators', () => {
     });
   });
 
+  it('should validate booleans with option loose set to true', () => {
+    test({
+      validator: 'isBoolean',
+      args: [
+        { loose: true },
+      ],
+      valid: [
+        'true',
+        'True',
+        'TRUE',
+        'false',
+        'False',
+        'FALSE',
+        '0',
+        '1',
+        'yes',
+        'Yes',
+        'YES',
+        'no',
+        'No',
+        'NO',
+      ],
+      invalid: [
+        '1.0',
+        '0.0',
+        'true ',
+        ' false',
+      ],
+    });
+  });
+
   const validISO8601 = [
     '2009-12T12:34',
     '2009',


### PR DESCRIPTION
This PR adds a loose option to the isBoolean validator. It defaults to `false`, and in that mode, nothing changes from the current behavior. 

When set to true, the validator will also validate `yes`, `no`, and will validate boolean strings of any case. (eg: `['true', 'True', 'TRUE', 'tRuE']`)

This PR satisfies the request in this issue. https://github.com/validatorjs/validator.js/issues/1672

## Checklist

- [x] PR contains only changes related; no stray files, etc.
- [x] README updated (where applicable)
- [x] Tests written (where applicable)
