### PR TITLE
refactor: outsource test-data to external package (starting with e-mail data as proof-of-concept)

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,5 +71,8 @@
   "engines": {
     "node": ">= 0.10"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "dependencies": {
+    "validation-test-data": "^1.0.0"
+  }
 }

--- a/test/validators.js
+++ b/test/validators.js
@@ -1,8 +1,9 @@
+import { email } from 'validation-test-data';
+import { format } from 'util';
 import assert from 'assert';
 import fs from 'fs';
-import { format } from 'util';
-import vm from 'vm';
 import validator from '../src/index';
+import vm from 'vm';
 
 let validator_js = fs.readFileSync(require.resolve('../validator.js')).toString();
 
@@ -61,62 +62,8 @@ describe('Validators', () => {
   it('should validate email addresses', () => {
     test({
       validator: 'isEmail',
-      valid: [
-        'foo@bar.com',
-        'x@x.au',
-        'foo@bar.com.au',
-        'foo+bar@bar.com',
-        'hans.m端ller@test.com',
-        'hans@m端ller.com',
-        'test|123@m端ller.com',
-        'test123+ext@gmail.com',
-        'some.name.midd.leNa.me+extension@GoogleMail.com',
-        '"foobar"@example.com',
-        '"  foo  m端ller "@example.com',
-        '"foo\\@bar"@example.com',
-        `${repeat('a', 64)}@${repeat('a', 63)}.com`,
-        `${repeat('a', 64)}@${repeat('a', 63)}.com`,
-        `${repeat('a', 31)}@gmail.com`,
-        'test@gmail.com',
-        'test.1@gmail.com',
-        'test@1337.com',
-      ],
-      invalid: [
-        'invalidemail@',
-        'invalid.com',
-        '@invalid.com',
-        'foo@bar.com.',
-        'somename@ｇｍａｉｌ.com',
-        'foo@bar.co.uk.',
-        'z@co.c',
-        'ｇｍａｉｌｇｍａｉｌｇｍａｉｌｇｍａｉｌｇｍａｉｌ@gmail.com',
-        `${repeat('a', 64)}@${repeat('a', 251)}.com`,
-        `${repeat('a', 65)}@${repeat('a', 250)}.com`,
-        `${repeat('a', 64)}@${repeat('a', 64)}.com`,
-        `${repeat('a', 64)}@${repeat('a', 63)}.${repeat('a', 63)}.${repeat('a', 63)}.${repeat('a', 58)}.com`,
-        'test1@invalid.co m',
-        'test2@invalid.co m',
-        'test3@invalid.co m',
-        'test4@invalid.co m',
-        'test5@invalid.co m',
-        'test6@invalid.co m',
-        'test7@invalid.co m',
-        'test8@invalid.co m',
-        'test9@invalid.co m',
-        'test10@invalid.co m',
-        'test11@invalid.co m',
-        'test12@invalid.co　m',
-        'test13@invalid.co　m',
-        'multiple..dots@stillinvalid.com',
-        'test123+invalid! sub_address@gmail.com',
-        'gmail...ignores...dots...@gmail.com',
-        'ends.with.dot.@gmail.com',
-        'multiple..dots@gmail.com',
-        'wrong()[]",:;<>@@gmail.com',
-        '"wrong()[]",:;<>@@gmail.com',
-        'username@domain.com�',
-        'username@domain.com©',
-      ],
+      valid: email.standard.valid,
+      invalid: email.standard.invalid,
     });
   });
 
@@ -144,30 +91,8 @@ describe('Validators', () => {
     test({
       validator: 'isEmail',
       args: [{ allow_utf8_local_part: false }],
-      valid: [
-        'foo@bar.com',
-        'x@x.au',
-        'foo@bar.com.au',
-        'foo+bar@bar.com',
-        'hans@m端ller.com',
-        'test|123@m端ller.com',
-        'test123+ext@gmail.com',
-        'some.name.midd.leNa.me+extension@GoogleMail.com',
-        '"foobar"@example.com',
-        '"foo\\@bar"@example.com',
-        '"  foo  bar  "@example.com',
-      ],
-      invalid: [
-        'invalidemail@',
-        'invalid.com',
-        '@invalid.com',
-        'foo@bar.com.',
-        'foo@bar.co.uk.',
-        'somename@ｇｍａｉｌ.com',
-        'hans.m端ller@test.com',
-        'z@co.c',
-        'tüst@invalid.com',
-      ],
+      valid: email.withoutUTF8CharsinLocalPart.valid,
+      invalid: email.withoutUTF8CharsinLocalPart.invalid,
     });
   });
 
@@ -175,62 +100,8 @@ describe('Validators', () => {
     test({
       validator: 'isEmail',
       args: [{ allow_display_name: true }],
-      valid: [
-        'foo@bar.com',
-        'x@x.au',
-        'foo@bar.com.au',
-        'foo+bar@bar.com',
-        'hans.m端ller@test.com',
-        'hans@m端ller.com',
-        'test|123@m端ller.com',
-        'test123+ext@gmail.com',
-        'some.name.midd.leNa.me+extension@GoogleMail.com',
-        'Some Name <foo@bar.com>',
-        'Some Name <x@x.au>',
-        'Some Name <foo@bar.com.au>',
-        'Some Name <foo+bar@bar.com>',
-        'Some Name <hans.m端ller@test.com>',
-        'Some Name <hans@m端ller.com>',
-        'Some Name <test|123@m端ller.com>',
-        'Some Name <test123+ext@gmail.com>',
-        '\'Foo Bar, Esq\'<foo@bar.com>',
-        'Some Name <some.name.midd.leNa.me+extension@GoogleMail.com>',
-        'Some Middle Name <some.name.midd.leNa.me+extension@GoogleMail.com>',
-        'Name <some.name.midd.leNa.me+extension@GoogleMail.com>',
-        'Name<some.name.midd.leNa.me+extension@GoogleMail.com>',
-        'Some Name <foo@gmail.com>',
-        'Name🍓With🍑Emoji🚴‍♀️🏆<test@aftership.com>',
-        '🍇🍗🍑<only_emoji@aftership.com>',
-        '"<displayNameInBrackets>"<jh@gmail.com>',
-        '"\\"quotes\\""<jh@gmail.com>',
-        '"name;"<jh@gmail.com>',
-        '"name;" <jh@gmail.com>',
-      ],
-      invalid: [
-        'invalidemail@',
-        'invalid.com',
-        '@invalid.com',
-        'foo@bar.com.',
-        'foo@bar.co.uk.',
-        'Some Name <invalidemail@>',
-        'Some Name <invalid.com>',
-        'Some Name <@invalid.com>',
-        'Some Name <foo@bar.com.>',
-        'Some Name <foo@bar.co.uk.>',
-        'Some Name foo@bar.co.uk.>',
-        'Some Name <foo@bar.co.uk.',
-        'Some Name < foo@bar.co.uk >',
-        'Name foo@bar.co.uk',
-        'Some Name <some..name@gmail.com>',
-        'Some Name<emoji_in_address🍈@aftership.com>',
-        'invisibleCharacter\u001F<jh@gmail.com>',
-        '<displayNameInBrackets><jh@gmail.com>',
-        '\\"quotes\\"<jh@gmail.com>',
-        '""quotes""<jh@gmail.com>',
-        'name;<jh@gmail.com>',
-        '    <jh@gmail.com>',
-        '"    "<jh@gmail.com>',
-      ],
+      valid: email.withDisplayNameOptional.valid,
+      invalid: email.withDisplayNameOptional.invalid,
     });
   });
 
@@ -238,45 +109,8 @@ describe('Validators', () => {
     test({
       validator: 'isEmail',
       args: [{ require_display_name: true }],
-      valid: [
-        'Some Name <foo@bar.com>',
-        'Some Name <x@x.au>',
-        'Some Name <foo@bar.com.au>',
-        'Some Name <foo+bar@bar.com>',
-        'Some Name <hans.m端ller@test.com>',
-        'Some Name <hans@m端ller.com>',
-        'Some Name <test|123@m端ller.com>',
-        'Some Name <test123+ext@gmail.com>',
-        'Some Name <some.name.midd.leNa.me+extension@GoogleMail.com>',
-        'Some Middle Name <some.name.midd.leNa.me+extension@GoogleMail.com>',
-        'Name <some.name.midd.leNa.me+extension@GoogleMail.com>',
-        'Name<some.name.midd.leNa.me+extension@GoogleMail.com>',
-      ],
-      invalid: [
-        'some.name.midd.leNa.me+extension@GoogleMail.com',
-        'foo@bar.com',
-        'x@x.au',
-        'foo@bar.com.au',
-        'foo+bar@bar.com',
-        'hans.m端ller@test.com',
-        'hans@m端ller.com',
-        'test|123@m端ller.com',
-        'test123+ext@gmail.com',
-        'invalidemail@',
-        'invalid.com',
-        '@invalid.com',
-        'foo@bar.com.',
-        'foo@bar.co.uk.',
-        'Some Name <invalidemail@>',
-        'Some Name <invalid.com>',
-        'Some Name <@invalid.com>',
-        'Some Name <foo@bar.com.>',
-        'Some Name <foo@bar.co.uk.>',
-        'Some Name foo@bar.co.uk.>',
-        'Some Name <foo@bar.co.uk.',
-        'Some Name < foo@bar.co.uk >',
-        'Name foo@bar.co.uk',
-      ],
+      valid: email.withDisplayNameRequired.valid,
+      invalid: email.withDisplayNameRequired.invalid,
     });
   });
 
@@ -284,15 +118,8 @@ describe('Validators', () => {
     test({
       validator: 'isEmail',
       args: [{ allow_ip_domain: true }],
-      valid: [
-        'email@[123.123.123.123]',
-        'email@255.255.255.255',
-      ],
-      invalid: [
-        'email@0.0.0.256',
-        'email@26.0.0.256',
-        'email@[266.266.266.266]',
-      ],
+      valid: email.withIPAddressDomain.valid,
+      invalid: email.withIPAddressDomain.invalid,
     });
   });
 
@@ -314,18 +141,14 @@ describe('Validators', () => {
     test({
       validator: 'isEmail',
       args: [{ ignore_max_length: false }],
-      valid: [],
-      invalid: [
-        'Deleted-user-id-19430-Team-5051deleted-user-id-19430-team-5051XXXXXX@example.com',
-      ],
+      valid: email.withExcessMaxLength.invalid,
+      invalid: email.withExcessMaxLength.valid,
     });
 
     test({
       validator: 'isEmail',
       args: [{ ignore_max_length: true }],
-      valid: [
-        'Deleted-user-id-19430-Team-5051deleted-user-id-19430-team-5051XXXXXX@example.com',
-      ],
+      valid: email.withExcessMaxLength.valid,
       invalid: [],
     });
   });


### PR DESCRIPTION
## Problem statement

If you need to test some data-validation logic, reliable test-data is most of the time hard to come by. Browsing through 100's of pages of data-format standards in order to produce good-quality test data which covers every possible edge case with regards to syntax-idiosyncrasies is also not an option because your day has only 24 hours.

Therefore, it would be great I you could re-use some already existing test-data for testing your data-validation task(s).

This project already contains a huge amount of battle-tested but not reusable test-data for different data-validation tasks in the file `test/validators.js`.

The goal of this PR is to makes the aforementioned test-data reusable.

## Solution

The test-data will be outsourced to a separate package (e.g. [validation-test-data](https://www.npmjs.com/package/validation-test-data)) which can then be imported by every application that needs it.

## Checklist of things done

- [x] Created and published example [validation-test-data](https://www.npmjs.com/package/validation-test-data) package which contains only e-mail test data for now.
- [x] Updated `test/validators.js` in order to pull-in the e-mail test data from the validation-test-data package

## Checklist of things to do

Should the idea presented in this PR find support:

- [ ] Outsource all test-data currently residing in `test/validators.js` to external package
- [ ] Providing documentation for the external test-data package
