### PR TITLE
fix(isEmail): replace all dots in gmail length validation

### DIFF
--- a/src/lib/isEmail.js
+++ b/src/lib/isEmail.js
@@ -110,7 +110,7 @@ export default function isEmail(str, options) {
     const username = user.split('+')[0];
 
     // Dots are not included in gmail length restriction
-    if (!isByteLength(username.replace('.', ''), { min: 6, max: 30 })) {
+    if (!isByteLength(username.replace(/\./g, ''), { min: 6, max: 30 })) {
       return false;
     }
 

--- a/test/validators.js
+++ b/test/validators.js
@@ -70,7 +70,7 @@ describe('Validators', () => {
         'hans@m端ller.com',
         'test|123@m端ller.com',
         'test123+ext@gmail.com',
-        'some.name.midd.leNa.me+extension@GoogleMail.com',
+        'some.name.midd.leNa.me.and.locality+extension@GoogleMail.com',
         '"foobar"@example.com',
         '"  foo  m端ller "@example.com',
         '"foo\\@bar"@example.com',


### PR DESCRIPTION
The gmail domain specific validator checks the length of the username part and replaces dots as they don't count against the limit. But the replace function only replaced the first dot. Fixed by using regex with g switch.

## Checklist

- [x] PR contains only changes related; no stray files, etc.
- [x] README updated (where applicable)
- [x] Tests written (where applicable)
