### PR TITLE
fix(rtrim): remove regex to prevent ReDOS attack

### DIFF
--- a/src/lib/rtrim.js
+++ b/src/lib/rtrim.js
@@ -2,7 +2,16 @@ import assertString from './util/assertString';
 
 export default function rtrim(str, chars) {
   assertString(str);
-  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#Escaping
-  const pattern = chars ? new RegExp(`[${chars.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}]+$`, 'g') : /(\s)+$/g;
-  return str.replace(pattern, '');
+  if (chars) {
+    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#Escaping
+    const pattern = new RegExp(`[${chars.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}]+$`, 'g');
+    return str.replace(pattern, '');
+  }
+  // Use a faster and more safe than regex trim method https://blog.stevenlevithan.com/archives/faster-trim-javascript
+  let strIndex = str.length - 1;
+  while (/\s/.test(str.charAt(strIndex))) {
+    strIndex -= 1;
+  }
+
+  return str.slice(0, strIndex + 1);
 }


### PR DESCRIPTION
This PR fixes a potential ReDOS in `rtrim` sanitizer. A try has been made in #1603 to fix the same vulnerability but it looks like we failed to prevent it.

The new implementation is not based on regex and is inspired by Steven Levithan's [blog post](https://blog.stevenlevithan.com/archives/faster-trim-javascript) and [trim package](https://www.npmjs.com/package/trim) implementation.

Thanks to @yetingli for discovering the vulnerability and [huntr.dev](https://huntr.dev) for reporting it
## Checklist

- [x] PR contains only changes related; no stray files, etc.

