### PR TITLE
feat(isDecimal): brief title of what has been donesupport for exponential decimals in isDecimal

### DIFF
--- a/src/lib/isDecimal.js
+++ b/src/lib/isDecimal.js
@@ -8,10 +8,13 @@ function decimalRegExp(options) {
   return regExp;
 }
 
+const exponentialRegexp = new RegExp('^[-+]?([0-9]+)$');
+
 const default_decimal_options = {
   force_decimal: false,
   decimal_digits: '1,',
   locale: 'en-US',
+  allow_exponential: false,
 };
 
 const blacklist = ['', '-', '+'];
@@ -20,7 +23,12 @@ export default function isDecimal(str, options) {
   assertString(str);
   options = merge(options, default_decimal_options);
   if (options.locale in decimal) {
-    return !includes(blacklist, str.replace(/ /g, '')) && decimalRegExp(options).test(str);
+    if (!options.allow_exponential) {
+      return !includes(blacklist, str.replace(/ /g, '')) && decimalRegExp(options).test(str);
+    }
+    const [decimalPart, exponential] = str.split(new RegExp('e', 'i'));
+    return !includes(blacklist, decimalPart.replace(/ /g, '')) && decimalRegExp(options).test(decimalPart) && exponentialRegexp.test(exponential);
   }
+
   throw new Error(`Invalid locale '${options.locale}'`);
 }

--- a/test/validators.js
+++ b/test/validators.js
@@ -3106,6 +3106,7 @@ describe('Validators', () => {
         '.',
         '0.1a',
         'a',
+        '1.23e4',
         '\n',
       ],
     });
@@ -3375,6 +3376,24 @@ describe('Validators', () => {
         '123',
         '0.01',
         '0,01',
+      ],
+    });
+  });
+
+  it('should validate decimal numbers with exponential', () => {
+    test({
+      validator: 'isDecimal',
+      args: [{ allow_exponential: true }],
+      valid: [
+        '12.3e4',
+        '12.3E4',
+        '1.23e+4',
+        '0.345e-6',
+        '+1.3e-4',
+      ],
+      invalid: [
+        '1.2e',
+        'e-2',
       ],
     });
   });


### PR DESCRIPTION

<!--- briefly describe what you have done in this PR --->
added a new option `allow_exponential `that allows exponential notation for decimals eg: 12.43e4 

the default value of `allow_exponential `is false

## Checklist

- [ ] PR contains only changes related; no stray files, etc.
- [ ] README updated (where applicable)
- [ ] Tests written (where applicable)
