### PR TITLE
feat(isISO639Alpha2): implement `isISO639Alpha2` validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Validator                               | Description
 **isISO31661Alpha2(str)**               | check if the string is a valid [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) officially assigned country code.
 **isISO31661Alpha3(str)**               | check if the string is a valid [ISO 3166-1 alpha-3](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3) officially assigned country code.
 **isISO4217(str)**                      | check if the string is a valid [ISO 4217](https://en.wikipedia.org/wiki/ISO_4217) officially assigned currency code.
+**isISO639Alpha2(str)**                 | check if the string is a valid [ISO 639-1 alpha-2](https://en.wikipedia.org/wiki/ISO_639-1) officially assigned language code.
 **isISRC(str)**                         | check if the string is a [ISRC](https://en.wikipedia.org/wiki/International_Standard_Recording_Code).
 **isISSN(str [, options])**             | check if the string is an [ISSN](https://en.wikipedia.org/wiki/International_Standard_Serial_Number).<br/><br/>`options` is an object which defaults to `{ case_sensitive: false, require_hyphen: false }`. If `case_sensitive` is true, ISSNs with a lowercase `'x'` as the check digit are rejected.
 **isJSON(str [, options])**             | check if the string is valid JSON (note: uses JSON.parse).<br/><br/>`options` is an object which defaults to `{ allow_primitives: false }`. If `allow_primitives` is true, the primitives 'true', 'false' and 'null' are accepted as valid JSON values.

--- a/src/index.js
+++ b/src/index.js
@@ -91,6 +91,7 @@ import isRFC3339 from './lib/isRFC3339';
 import isISO31661Alpha2 from './lib/isISO31661Alpha2';
 import isISO31661Alpha3 from './lib/isISO31661Alpha3';
 import isISO4217 from './lib/isISO4217';
+import isISO639Alpha2 from './lib/isISO639Alpha2';
 
 import isBase32 from './lib/isBase32';
 import isBase58 from './lib/isBase58';
@@ -200,6 +201,7 @@ const validator = {
   isISO31661Alpha2,
   isISO31661Alpha3,
   isISO4217,
+  isISO639Alpha2,
   isBase32,
   isBase58,
   isBase64,

--- a/src/lib/isISO639Alpha2.js
+++ b/src/lib/isISO639Alpha2.js
@@ -1,0 +1,37 @@
+import assertString from './util/assertString';
+
+// https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes
+const validISO639Alpha2Codes = new Set([
+  'aa', 'ab', 'ae', 'af', 'ak', 'am', 'an', 'ar', 'as', 'av', 'ay', 'az',
+  'ba', 'be', 'bg', 'bi', 'bm', 'bn', 'bo', 'br', 'bs',
+  'ca', 'ce', 'ch', 'co', 'cr', 'cs', 'cu', 'cv', 'cy',
+  'da', 'de', 'dv', 'dz',
+  'ee', 'el', 'en', 'eo', 'es', 'et', 'eu',
+  'fa', 'ff', 'fi', 'fj', 'fo', 'fr', 'fy',
+  'ga', 'gd', 'gl', 'gn', 'gu', 'gv',
+  'ha', 'he', 'hi', 'ho', 'hr', 'ht', 'hu', 'hy', 'hz',
+  'ia', 'id', 'ie', 'ig', 'ii', 'ik', 'io', 'is', 'it', 'iu',
+  'ja', 'jv',
+  'ka', 'kg', 'ki', 'kj', 'kk', 'kl', 'km', 'kn', 'ko', 'kr', 'ks', 'ku', 'kv', 'kw', 'ky',
+  'la', 'lb', 'lg', 'li', 'ln', 'lo', 'lt', 'lu', 'lv',
+  'mg', 'mh', 'mi', 'mk', 'ml', 'mn', 'mr', 'ms', 'mt', 'my',
+  'na', 'nb', 'nd', 'ne', 'ng', 'nl', 'nn', 'no', 'nr', 'nv', 'ny',
+  'oc', 'oj', 'om', 'or', 'os',
+  'pa', 'pi', 'pl', 'ps', 'pt',
+  'qu',
+  'rm', 'rn', 'ro', 'ru', 'rw',
+  'sa', 'sc', 'sd', 'se', 'sg', 'si', 'sk', 'sl', 'sm', 'sn', 'so', 'sq', 'sr', 'ss', 'st', 'su', 'sv', 'sw',
+  'ta', 'te', 'tg', 'th', 'ti', 'tk', 'tl', 'tn', 'to', 'tr', 'ts', 'tt', 'tw', 'ty',
+  'ug', 'uk', 'ur', 'uz',
+  've', 'vi', 'vo', 'wa', 'wo',
+  'xh',
+  'yi', 'yo',
+  'za', 'zh', 'zu',
+]);
+
+export default function isISO639Alpha2(str) {
+  assertString(str);
+  return validISO639Alpha2Codes.has(str.toLowerCase());
+}
+
+export const LanguageCodes = validISO639Alpha2Codes;

--- a/test/validators.js
+++ b/test/validators.js
@@ -9413,6 +9413,37 @@ describe('Validators', () => {
     });
   });
 
+  it('should validate ISO 639 Alpha 2 language codes', () => {
+    test({
+      validator: 'isISO639Alpha2',
+      valid: [
+        'cs',
+        'da',
+        'de',
+        'en',
+        'es',
+        'fi',
+        'fr',
+        'nb',
+        'nl',
+        'pl',
+        'pt',
+        'ru',
+      ],
+      invalid: [
+        'ASDF',
+        'cz',
+        'dk',
+        'eng',
+        'jp',
+        'nld',
+        'sp',
+        'xx',
+        'zz',
+      ],
+    });
+  });
+
   it('should validate whitelisted characters', () => {
     test({
       validator: 'isWhitelisted',


### PR DESCRIPTION
<!--- briefly describe what you have done in this PR --->

I've added a validator for ISO 639 Alpha-2 language codes.

I think I've done everything correctly here, but it's my first time contributing to this project so it might be a good idea if someone gives it a good glance.

## Checklist

- [X] PR contains only changes related; no stray files, etc.
- [X] README updated (where applicable)
- [X] Tests written (where applicable)
