### PR TITLE
fix(isUUID): handle of null version value

### DIFF
--- a/src/lib/isUUID.js
+++ b/src/lib/isUUID.js
@@ -7,8 +7,8 @@ const uuid = {
   all: /^[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}$/i,
 };
 
-export default function isUUID(str, version = 'all') {
+export default function isUUID(str, version) {
   assertString(str);
-  const pattern = uuid[version];
+  const pattern = uuid[![undefined, null].includes(version) ? version : 'all'];
   return pattern && pattern.test(str);
 }

--- a/test/validators.js
+++ b/test/validators.js
@@ -4415,6 +4415,34 @@ describe('Validators', () => {
     });
     test({
       validator: 'isUUID',
+      args: [undefined],
+      valid: [
+        'A117FBC9-4BED-3078-CF07-9141BA07C9F3',
+        'A117FBC9-4BED-5078-AF07-9141BA07C9F3',
+      ],
+      invalid: [
+        '',
+        'xxxA987FBC9-4BED-3078-CF07-9141BA07C9F3',
+        'A987FBC94BED3078CF079141BA07C9F3',
+        'A11AAAAA-1111-1111-AAAG-111111111111',
+      ],
+    });
+    test({
+      validator: 'isUUID',
+      args: [null],
+      valid: [
+        'A127FBC9-4BED-3078-CF07-9141BA07C9F3',
+      ],
+      invalid: [
+        '',
+        'xxxA987FBC9-4BED-3078-CF07-9141BA07C9F3',
+        'A127FBC9-4BED-3078-CF07-9141BA07C9F3xxx',
+        '912859',
+        'A12AAAAA-1111-1111-AAAG-111111111111',
+      ],
+    });
+    test({
+      validator: 'isUUID',
       args: [3],
       valid: [
         'A987FBC9-4BED-3078-CF07-9141BA07C9F3',


### PR DESCRIPTION


<!--- briefly describe what you have done in this PR --->
The issue here lies in that, where the defaulting of argument is only managed for when the value of the version is 'undefined', and for other falsy values (in my case 'null') it accepts them. There are cases where functions do trigger callbacks with null values instead of undefined, and it usually leads to unexpected outcomes. I do believe that this is the general understanding of how the function should be used, when the version argument is falsy, it should check for 'all' pattern.

The particular issue is here:

<img width="717" alt="Screenshot 2021-10-12 at 13 48 29" src="https://user-images.githubusercontent.com/31168388/136959544-b3d5cb01-6074-4676-998d-3d5696331f0f.png">

## Checklist

- [x] PR contains only changes related; no stray files, etc.
- [ ] README updated (where applicable)
- [x] Tests written (where applicable)
