### PR TITLE
chore: pin eslint-plugin-import

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "eslint": "^4.19.1",
     "eslint-config-airbnb-base": "^12.1.0",
     "eslint-plugin-import": "2.24.2",
+    "eslint-module-utils": "2.6.2",
     "mocha": "^6.2.3",
     "nyc": "^14.1.0",
     "rimraf": "^3.0.0",


### PR DESCRIPTION
Tests started failing on our CI pipline for Node.js 6 some days ago (An example can be found [here](https://github.com/validatorjs/validator.js/runs/3866381345?check_suite_focus=true)). The issue is related to eslint, more specificly eslint-module-import and there is an open PR to resolve the problem (https://github.com/import-js/eslint-plugin-import/pull/2261)

We probably need to drop support in CI to Node.js 6.0. as mentioned in #1783, we are keeping support for Node.js in our pipeline to prevent merging code containing code not supported in some browsers (lookbehind regular expressions as an example).

The ideal way to fix this issue would be to add browser tests (Already a WIP, not sure if i will be able to finish it this week). This PR introduces a temporary solution by pinning `eslint-plugin-import` version in order to allow any future and past failing tests to pass. 

EDIT: pinning `eslint-module-utils` was also necessary to fix the issue
