### PR TITLE
improvement(eslint) upgrading version of eslint to 5.16.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@babel/register": "^7.0.0",
     "babel-eslint": "^10.0.1",
     "babel-plugin-add-module-exports": "^1.0.0",
-    "eslint": "^4.19.1",
+    "eslint": "^5.16.0",
     "eslint-config-airbnb-base": "^12.1.0",
     "eslint-plugin-import": "^2.11.0",
     "mocha": "^6.2.3",


### PR DESCRIPTION
Since the eslint version is a bit outdate and does cause issues on PR-s, the aim of this PR is to try to upgrade it for the version that is possible at this point.

It seems that the highest eslint version compatible with all whitelisted node versions for testing, is version 5.16.0.

## Checklist

- [x] PR contains only changes related; no stray files, etc.
- [ ] README updated (where applicable)
- [ ] Tests written (where applicable)
