### PR TITLE
feat(isUrl):  urls with empty user

### DIFF
--- a/src/lib/isURL.js
+++ b/src/lib/isURL.js
@@ -114,8 +114,8 @@ export default function isURL(url, options) {
     if (split[0] === '') {
       return false;
     }
-    const user_password = split[0].split(':');
-    if (user_password[0] === '' && user_password[1] === '') {
+    const [user, password] = split[0].split(':');
+    if (user === '' && password === '') {
       return false;
     }
     auth = split.shift();

--- a/src/lib/isURL.js
+++ b/src/lib/isURL.js
@@ -114,12 +114,12 @@ export default function isURL(url, options) {
     if (split[0] === '') {
       return false;
     }
-    const [user, password] = split[0].split(':');
-    if (user === '' && password === '') {
-      return false;
-    }
     auth = split.shift();
     if (auth.indexOf(':') >= 0 && auth.split(':').length > 2) {
+      return false;
+    }
+    const [user, password] = auth.split(':');
+    if (user === '' && password === '') {
       return false;
     }
   }

--- a/src/lib/isURL.js
+++ b/src/lib/isURL.js
@@ -111,7 +111,11 @@ export default function isURL(url, options) {
     if (options.disallow_auth) {
       return false;
     }
-    if (split[0] === '' || split[0].substr(0, 1) === ':') {
+    if (split[0] === '') {
+      return false;
+    }
+    const user_password = split[0].split(':');
+    if (user_password[0] === '' && user_password[1] === '') {
       return false;
     }
     auth = split.shift();

--- a/test/validators.js
+++ b/test/validators.js
@@ -364,6 +364,7 @@ describe('Validators', () => {
         'http://www.foobar.com/~foobar',
         'http://user:pass@www.foobar.com/',
         'http://user:@www.foobar.com/',
+        'http://:pass@www.foobar.com/',
         'http://user@www.foobar.com',
         'http://127.0.0.1/',
         'http://10.0.0.0/',


### PR DESCRIPTION
URL with an empty user are valid.

Example:
```
http://:pass@www.foobar.com/
```

This kind of URL (${protocol}://:${password}@${hostname}:${port}) can be parsed and allows to extract the password.
discussion: https://github.com/validatorjs/validator.js/issues/1681

## Checklist

- [x] PR contains only changes related; no stray files, etc.
- [x] README updated (where applicable)
- [X] Tests written (where applicable)
