### PR TITLE
fix(unescape-bug): Fixed bug where intermediate string contains escaped characters

### DIFF
--- a/src/lib/unescape.js
+++ b/src/lib/unescape.js
@@ -10,4 +10,7 @@ export default function unescape(str) {
     .replace(/&#x5C;/g, '\\')
     .replace(/&#96;/g, '`')
     .replace(/&amp;/g, '&'));
+  // &amp; replacement has to be the last one to prevent
+  // bugs with intermediate strings containing escape sequences
+  // See: https://github.com/validatorjs/validator.js/issues/1827
 }

--- a/src/lib/unescape.js
+++ b/src/lib/unescape.js
@@ -2,12 +2,12 @@ import assertString from './util/assertString';
 
 export default function unescape(str) {
   assertString(str);
-  return (str.replace(/&amp;/g, '&')
-    .replace(/&quot;/g, '"')
+  return (str.replace(/&quot;/g, '"')
     .replace(/&#x27;/g, "'")
     .replace(/&lt;/g, '<')
     .replace(/&gt;/g, '>')
     .replace(/&#x2F;/g, '/')
     .replace(/&#x5C;/g, '\\')
-    .replace(/&#96;/g, '`'));
+    .replace(/&#96;/g, '`')
+    .replace(/&amp;/g, '&'));
 }

--- a/test/sanitizers.js
+++ b/test/sanitizers.js
@@ -184,6 +184,9 @@ describe('Sanitizers', () => {
 
         'Backtick: &#96;':
             'Backtick: `',
+
+        'Escaped string: &amp;lt;':
+            'Escaped string: &lt;',
       },
     });
   });


### PR DESCRIPTION
Fixes: #1827 

If the intermediate string contains escape sequences, eg. unescaping `&amp;lt;` resulted in incorrect output `<`. Moved &amp; unescape as last operation to handle all other sequences before that.

## Checklist

- [X] PR contains only changes related; no stray files, etc.
- [ ] README updated (where applicable) - not applicable
- [X] Tests written (where applicable)
