### PR TITLE
chore(CI): Cache dependencies in GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,13 +12,14 @@ jobs:
         node-version: [14, 12, 10, 8, 6]
     name: Run tests on Node.js ${{ matrix.node-version }}
     steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
     - name: Setup Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v2-beta
+      uses: actions/setup-node@v2
       with:
         node-version: ${{ matrix.node-version }}
         check-latest: true
-    - name: Checkout repository
-      uses: actions/checkout@v2
+        cache: 'npm'
     - name: Install dependencies
       run: npm install
     - name: Run tests


### PR DESCRIPTION
PR to speed up CI times on GitHub Actions by caching dependencies. This PR also bumps `actions/checkout` and `actions/setup-node` to the latest versions.

References:
* https://github.com/actions/setup-node#caching-packages-dependencies

## Checklist

- [ ] PR contains only changes related; no stray files, etc.
- [ ] README updated (where applicable)
- [ ] Tests written (where applicable)
