### PR TITLE
Add a security policy for the repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@
 [![Downloads][downloads-image]][npm-url]
 [![Backers on Open Collective](https://opencollective.com/validatorjs/backers/badge.svg)](#backers)
 [![Sponsors on Open Collective](https://opencollective.com/validatorjs/sponsors/badge.svg)](#sponsors)
-[![Gitter](https://badges.gitter.im/validatorjs/community.svg)](https://gitter.im/validatorjs/community)
+[![Gitter][gitter-image]][gitter-url]
+[![Disclose a vulnerability][huntr-image]][huntr-url]
 
 A library of string validators and sanitizers.
 
@@ -266,6 +267,12 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 [ci-url]: https://github.com/validatorjs/validator.js/actions?query=workflow%3ACI
 [ci-image]: https://github.com/validatorjs/validator.js/workflows/CI/badge.svg?branch=master
+
+[gitter-url]: https://gitter.im/validatorjs/community
+[gitter-image]: https://badges.gitter.im/validatorjs/community.svg
+
+[huntr-url]: https://huntr.dev/bounties/disclose/?target=https://github.com/validatorjs/validator.js
+[huntr-image]: https://cdn.huntr.dev/huntr_security_badge_mono.svg
 
 [amd]: http://requirejs.org/docs/whyamd.html
 [bower]: http://bower.io/

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,11 @@
+# Security Policy
+
+## Supported Versions
+
+In the case of a confirmed security issue, only the current version of validator is guaranteed to be patched.
+
+## Reporting a Vulnerability
+
+**Please don't disclose security-related issues publicly.**
+
+If you discover a vulnerability within validator, please use [huntr.dev disclosure form](https://huntr.dev/bounties/disclose/?target=https://github.com/validatorjs/validator.js). We will try to validate and respond to reports in a reasonable time. if the issue is confirmed, we will create a security advisory and a patch as soon as possible.


### PR DESCRIPTION
Hello,
As discussed in #1726 , we need a security policy to allow security researchers to report to us security vulnerabilities privately.

This PR is adding a security policy and a readme badge to facilitate vulnerability reports. I added [huntr.dev ](https://huntr.dev) because we already have 2 security vulnerabilities disclosed using that platform and the experience went very well.

