### PR TITLE
fix(isDataURI): fix dataURI mediaType format

### DIFF
--- a/src/lib/isDataURI.js
+++ b/src/lib/isDataURI.js
@@ -1,6 +1,6 @@
 import assertString from './util/assertString';
 
-const validMediaType = /^[a-z]+\/[a-z0-9\-\+]+$/i;
+const validMediaType = /^[a-z]+\/[a-z0-9\-\+\.]+$/i;
 
 const validAttribute = /^[a-z\-]+=[a-z0-9\-]+$/i;
 

--- a/test/validators.js
+++ b/test/validators.js
@@ -10151,7 +10151,7 @@ describe('Validators', () => {
         ' data:text/html,%3Ch1%3EHello%2C%20World!%3C%2Fh1%3E',
         'data:,A%20brief%20note',
         'data:text/html;charset=US-ASCII,%3Ch1%3EHello!%3C%2Fh1%3E',
-        'data:application/vnd.openxmlformats-officedocument.wordprocessingml.document;base64,dGVzdC5kb2N4'
+        'data:application/vnd.openxmlformats-officedocument.wordprocessingml.document;base64,dGVzdC5kb2N4',
       ],
       invalid: [
         'dataxbase64',

--- a/test/validators.js
+++ b/test/validators.js
@@ -10151,7 +10151,7 @@ describe('Validators', () => {
         ' data:text/html,%3Ch1%3EHello%2C%20World!%3C%2Fh1%3E',
         'data:,A%20brief%20note',
         'data:text/html;charset=US-ASCII,%3Ch1%3EHello!%3C%2Fh1%3E',
-        'data:application/vndopenxmlformats-officedocumentwordprocessingmldocument;base64,dGVzdC5kb2N4',
+        'data:application/vnd.openxmlformats-officedocument.wordprocessingml.document;base64,dGVzdC5kb2N4'
       ],
       invalid: [
         'dataxbase64',

--- a/test/validators.js
+++ b/test/validators.js
@@ -10151,6 +10151,7 @@ describe('Validators', () => {
         ' data:text/html,%3Ch1%3EHello%2C%20World!%3C%2Fh1%3E',
         'data:,A%20brief%20note',
         'data:text/html;charset=US-ASCII,%3Ch1%3EHello!%3C%2Fh1%3E',
+        'data:application/vndopenxmlformats-officedocumentwordprocessingmldocument;base64,dGVzdC5kb2N4',
       ],
       invalid: [
         'dataxbase64',


### PR DESCRIPTION
fix(isDataURI): fix dataURI mediaType format

The readAsDataURL method [MDN](https://developer.mozilla.org/en-US/docs/Web/API/FileReader/readAsDataURL) generates a dot mediaType for some file formats (.docx - application/vnd.openxmlformats-officedocument.wordprocessingml.document, . xlsx - application/vnd.openxmlformats-officedocument.spreadsheetml.sheet).
I extended the mediaType validation pattern to be compatible with readAsDataURL.

## Checklist

- [x] PR contains only changes related; no stray files, etc.
- [ ] README updated (where applicable)
- [x] Tests written (where applicable)
