### PR TITLE
fix(isFQDN): allow_numeric_tld option didn't work

### DIFF
--- a/src/lib/isFQDN.js
+++ b/src/lib/isFQDN.js
@@ -32,7 +32,7 @@ export default function isFQDN(str, options) {
       return false;
     }
 
-    if (!/^([a-z\u00A1-\u00A8\u00AA-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]{2,}|xn[a-z0-9-]{2,})$/i.test(tld)) {
+    if (!options.allow_numeric_tld && !/^([a-z\u00A1-\u00A8\u00AA-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]{2,}|xn[a-z0-9-]{2,})$/i.test(tld)) {
       return false;
     }
 

--- a/test/validators.js
+++ b/test/validators.js
@@ -1291,7 +1291,18 @@ describe('Validators', () => {
       ],
     });
   });
-
+  it('should validate FQDN with required allow_trailing_dot, allow_underscores and allow_numeric_tld options', () => {
+    test({
+      validator: 'isFQDN',
+      args: [
+        { allow_trailing_dot: true, allow_underscores: true, allow_numeric_tld: true },
+      ],
+      valid: [
+        'abc.efg.g1h.',
+        'as1s.sad3s.ssa2d.',
+      ],
+    });
+  });
   it('should validate alpha strings', () => {
     test({
       validator: 'isAlpha',


### PR DESCRIPTION
According to the mentioned on this comment https://github.com/validatorjs/validator.js/issues/1923#issuecomment-1029809187

> Example: `abc.efg.g1h.` will always fail, current `options` don't provide this use case, but is valid
> 
> ```js
> validator.isFQDN('abc.efg.g1h.', 
>   { allow_trailing_dot: true, allow_underscores: true, allow_numeric_tld: true}); // false but should be true
> ```

the option allow_numeric_tld didn't work as supposed to do, this PR tries to fix that.

## Checklist

- [x] PR contains only changes related; no stray files, etc.
- [x] README updated (where applicable)
- [x] Tests written (where applicable)
