### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/src/lib/isDataURI.js
+++ b/src/lib/isDataURI.js
@@ -14,10 +14,10 @@ export default function isDataURI(str) {
   }
   const attributes = data.shift().trim().split(';');
   const schemeAndMediaType = attributes.shift();
-  if (schemeAndMediaType.substr(0, 5) !== 'data:') {
+  if (schemeAndMediaType.slice(0, 5) !== 'data:') {
     return false;
   }
-  const mediaType = schemeAndMediaType.substr(5);
+  const mediaType = schemeAndMediaType.slice(5);
   if (mediaType !== '' && !validMediaType.test(mediaType)) {
     return false;
   }

--- a/src/lib/isEmail.js
+++ b/src/lib/isEmail.js
@@ -77,7 +77,7 @@ export default function isEmail(str, options) {
       // eg. myname <address@gmail.com>
       // the display name is `myname` instead of `myname `, so need to trim the last space
       if (display_name.endsWith(' ')) {
-        display_name = display_name.substr(0, display_name.length - 1);
+        display_name = display_name.slice(0, -1);
       }
 
       if (!validateDisplayName(display_name)) {
@@ -144,7 +144,7 @@ export default function isEmail(str, options) {
         return false;
       }
 
-      let noBracketdomain = domain.substr(1, domain.length - 2);
+      let noBracketdomain = domain.slice(1, -1);
 
       if (noBracketdomain.length === 0 || !isIP(noBracketdomain)) {
         return false;

--- a/src/lib/isIdentityCard.js
+++ b/src/lib/isIdentityCard.js
@@ -130,15 +130,15 @@ const validators = {
   },
   IR: (str) => {
     if (!str.match(/^\d{10}$/)) return false;
-    str = (`0000${str}`).substr(str.length - 6);
+    str = (`0000${str}`).slice(str.length - 6);
 
-    if (parseInt(str.substr(3, 6), 10) === 0) return false;
+    if (parseInt(str.slice(3, 9), 10) === 0) return false;
 
-    const lastNumber = parseInt(str.substr(9, 1), 10);
+    const lastNumber = parseInt(str.slice(9, 10), 10);
     let sum = 0;
 
     for (let i = 0; i < 9; i++) {
-      sum += parseInt(str.substr(i, 1), 10) * (10 - i);
+      sum += parseInt(str.slice(i, i + 1), 10) * (10 - i);
     }
 
     sum %= 11;

--- a/src/lib/isTaxID.js
+++ b/src/lib/isTaxID.js
@@ -373,7 +373,7 @@ function enUsGetPrefixes() {
  * Verify that the TIN starts with a valid IRS campus prefix
  */
 function enUsCheck(tin) {
-  return enUsGetPrefixes().indexOf(tin.substr(0, 2)) !== -1;
+  return enUsGetPrefixes().indexOf(tin.slice(0, 2)) !== -1;
 }
 
 /*

--- a/src/lib/isURL.js
+++ b/src/lib/isURL.js
@@ -87,11 +87,11 @@ export default function isURL(url, options) {
     }
   } else if (options.require_protocol) {
     return false;
-  } else if (url.substr(0, 2) === '//') {
+  } else if (url.slice(0, 2) === '//') {
     if (!options.allow_protocol_relative_urls) {
       return false;
     }
-    split[0] = url.substr(2);
+    split[0] = url.slice(2);
   }
   url = split.join('://');
 


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.

## Checklist

- [x] PR contains only changes related; no stray files, etc.
- [ ] README updated (where applicable)
- [ ] Tests written (where applicable)
