### PR TITLE
do not check if the host is valid if no host is specified and not require_host

### DIFF
--- a/src/lib/isURL.js
+++ b/src/lib/isURL.js
@@ -152,6 +152,11 @@ export default function isURL(url, options) {
   if (options.host_whitelist) {
     return checkHost(host, options.host_whitelist);
   }
+
+  if (host === '' && !options.require_host) {
+    return true;
+  }
+
   if (!isIP(host) && !isFQDN(host, options) && (!ipv6 || !isIP(ipv6, 6))) {
     return false;
   }

--- a/test/validators.js
+++ b/test/validators.js
@@ -472,6 +472,24 @@ describe('Validators', () => {
     });
   });
 
+  it('should validate postgres URLs without a host', () => {
+    test({
+      validator: 'isURL',
+      args: [{
+        protocols: ['postgres'],
+        require_host: false,
+      }],
+      valid: [
+        'postgres://user:pw@/test',
+      ],
+      invalid: [
+        'http://foobar.com',
+        'postgres://',
+      ],
+    });
+  });
+
+
   it('should validate URLs with any protocol', () => {
     test({
       validator: 'isURL',


### PR DESCRIPTION
# Fix the isURL check to not check the host if the host part is empty and require_host is false

This PR fixes isse #1994 

## Checklist

- [x] PR contains only changes related; no stray files, etc.
- [x] README updated (where applicable)
- [x] Tests written (where applicable)
