### PR TITLE
feat(isISO6391 & isISO31661Alpha3): Added exports for codes declarations

### DIFF
--- a/src/lib/isISO31661Alpha3.js
+++ b/src/lib/isISO31661Alpha3.js
@@ -24,3 +24,5 @@ export default function isISO31661Alpha3(str) {
   assertString(str);
   return validISO31661Alpha3CountriesCodes.has(str.toUpperCase());
 }
+
+export const CountryCodes = validISO31661Alpha3CountriesCodes;

--- a/src/lib/isISO6391.js
+++ b/src/lib/isISO6391.js
@@ -1,6 +1,7 @@
 import assertString from './util/assertString';
 
-const isISO6391Set = new Set([
+// from https://en.wikipedia.org/wiki/ISO_639-1
+const validISO6391LanguageCodes = new Set([
   'aa', 'ab', 'ae', 'af', 'ak', 'am', 'an', 'ar', 'as', 'av', 'ay', 'az', 'az',
   'ba', 'be', 'bg', 'bh', 'bi', 'bm', 'bn', 'bo', 'br', 'bs',
   'ca', 'ce', 'ch', 'co', 'cr', 'cs', 'cu', 'cv', 'cy',
@@ -31,5 +32,7 @@ const isISO6391Set = new Set([
 
 export default function isISO6391(str) {
   assertString(str);
-  return isISO6391Set.has(str);
+  return validISO6391LanguageCodes.has(str);
 }
+
+export const LanguageCodes = validISO6391LanguageCodes;


### PR DESCRIPTION
Added codes list declaration exports for `isISO6391` and `isISO31661Alpha3`.

[`isISO4217`](https://github.com/validatorjs/validator.js/blob/86a07ba4f3f710f639e92a62cf81dd3321ef9ee8/src/lib/isISO4217.js#L38) and [`isISO31661Alpha2`](https://github.com/validatorjs/validator.js/blob/86a07ba4f3f710f639e92a62cf81dd3321ef9ee8/src/lib/isISO31661Alpha2.js#L37) export their codes declaration list, but on [`isISO6391`](https://github.com/validatorjs/validator.js/blob/86a07ba4f3f710f639e92a62cf81dd3321ef9ee8/src/lib/isISO6391.js) and [`isISO31661Alpha3`](https://github.com/validatorjs/validator.js/blob/86a07ba4f3f710f639e92a62cf81dd3321ef9ee8/src/lib/isISO31661Alpha3.js), they are missing.

## Checklist

- [X] PR contains only changes related; no stray files, etc.
- [ ] README updated (where applicable)
- [ ] Tests written (where applicable)
