### PR TITLE
[Varnika|Yashna] Fix. IPv6 format is fixed

### DIFF
--- a/src/lib/isIP.js
+++ b/src/lib/isIP.js
@@ -42,7 +42,7 @@ const IPv6AddressRegExp = new RegExp('^(' +
   `(?:${IPv6SegmentFormat}:){2}(?:(:${IPv6SegmentFormat}){0,3}:${IPv4AddressFormat}|(:${IPv6SegmentFormat}){1,5}|:)|` +
   `(?:${IPv6SegmentFormat}:){1}(?:(:${IPv6SegmentFormat}){0,4}:${IPv4AddressFormat}|(:${IPv6SegmentFormat}){1,6}|:)|` +
   `(?::((?::${IPv6SegmentFormat}){0,5}:${IPv4AddressFormat}|(?::${IPv6SegmentFormat}){1,7}|:))` +
-  ')(%[0-9a-zA-Z-.:]{1,})?$');
+  ')(%[0-9a-zA-Z.]{1,})?$');
 
 export default function isIP(str, version = '') {
   assertString(str);

--- a/test/validators.js
+++ b/test/validators.js
@@ -1082,6 +1082,8 @@ describe('Validators', () => {
         '2001:db8:0000:1:1:1:1::1',
         '0:0:0:0:0:0:ffff:127.0.0.1',
         '0:0:0:0:ffff:127.0.0.1',
+        'BC:e4d5:c:e7b9::%40i0nccymtl9cwfKo.5vaeXLSGRMe:EDh2qs5wkhnPws5xQKqafjfAMm6wGFCJ.bVFsZfb',
+        '1dC:0DF8:62D:3AC::%KTatXocjaFVioS0RTNQl4mA.V151o0RSy.JIu-D-D8.d3171ZWsSJ7PK4YjkJCRN0F',
       ],
     });
     test({


### PR DESCRIPTION
Fixed the invalid IPv6 address format:
- BC:e4d5:c:e7b9::%40i0nccymtl9cwfKo.5vaeXLSGRMe:EDh2qs5wkhnPws5xQKqafjfAMm6wGFCJ.bVFsZfb
- 1dC:0DF8:62D:3AC::%KTatXocjaFVioS0RTNQl4mA.V151o0RSy.JIu-D-D8.d3171ZWsSJ7PK4YjkJCRN0F
as invalid


## Checklist

- [x] PR contains only changes related; no stray files, etc.
- [x] README updated (where applicable)
- [x] Tests written (where applicable)

"fixes https://github.com/validatorjs/validator.js/issues/2039"
