### PR TITLE
fix(isRgbColor): Fix validation of rgb(a)ColorPercentage strings

### DIFF
--- a/src/lib/isRgbColor.js
+++ b/src/lib/isRgbColor.js
@@ -2,8 +2,8 @@ import assertString from './util/assertString';
 
 const rgbColor = /^rgb\((([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5]),){2}([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\)$/;
 const rgbaColor = /^rgba\((([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5]),){3}(0?\.\d|1(\.0)?|0(\.0)?)\)$/;
-const rgbColorPercent = /^rgb\((([0-9]%|[1-9][0-9]%|100%),){2}([0-9]%|[1-9][0-9]%|100%)\)/;
-const rgbaColorPercent = /^rgba\((([0-9]%|[1-9][0-9]%|100%),){3}(0?\.\d|1(\.0)?|0(\.0)?)\)/;
+const rgbColorPercent = /^rgb\((([0-9]%|[1-9][0-9]%|100%),){2}([0-9]%|[1-9][0-9]%|100%)\)$/;
+const rgbaColorPercent = /^rgba\((([0-9]%|[1-9][0-9]%|100%),){3}(0?\.\d|1(\.0)?|0(\.0)?)\)$/;
 
 export default function isRgbColor(str, includePercentValues = true) {
   assertString(str);

--- a/test/validators.test.js
+++ b/test/validators.test.js
@@ -4359,6 +4359,8 @@ describe('Validators', () => {
         'rgba(3,3,3%,.3)',
         'rgb(101%,101%,101%)',
         'rgba(3%,3%,101%,0.3)',
+        'rgb(101%,101%,101%) additional invalid string part',
+        'rgba(3%,3%,101%,0.3) additional invalid string part',
       ],
     });
 


### PR DESCRIPTION
Fix validation of "rgb(a)ColorPercent" strings, see #2113 
The current RegExp is missing the "end of string" anchor, so it will also match values with additional string content after the actual rgb color part, kindly check the issue above for examples.


This fixes #2113 

## Checklist

- [x] PR contains only changes related; no stray files, etc.
- ~~[ ] README updated (where applicable)~~
- [x] Tests written (where applicable)
