### PR TITLE
refactor(isCreditCard): create allCards dynamically and get rid of hard-to-maintain hardcoded version

### DIFF
--- a/src/lib/isCreditCard.js
+++ b/src/lib/isCreditCard.js
@@ -14,6 +14,7 @@ const cards = {
 const allCards = (() => {
   const tmpCardsArray = [];
   for (const cardProvider in cards) {
+    // istanbul ignore else
     if (cards.hasOwnProperty(cardProvider)) {
       tmpCardsArray.push(cards[cardProvider]);
     }

--- a/src/lib/isCreditCard.js
+++ b/src/lib/isCreditCard.js
@@ -10,9 +10,16 @@ const cards = {
   unionpay: /^(6[27][0-9]{14}|^(81[0-9]{14,17}))$/,
   visa: /^(?:4[0-9]{12})(?:[0-9]{3,6})?$/,
 };
-/* eslint-disable max-len */
-const allCards = /^(?:4[0-9]{12}(?:[0-9]{3,6})?|5[1-5][0-9]{14}|(222[1-9]|22[3-9][0-9]|2[3-6][0-9]{2}|27[01][0-9]|2720)[0-9]{12}|6(?:011|5[0-9][0-9])[0-9]{12,15}|3[47][0-9]{13}|3(?:0[0-5]|[68][0-9])[0-9]{11}|(?:2131|1800|35\d{3})\d{11}|6[27][0-9]{14}|^(81[0-9]{14,17}))$/;
-/* eslint-enable max-len */
+
+const allCards = (() => {
+  const tmpCardsArray = [];
+  for (const cardProvider in cards) {
+    if (cards.hasOwnProperty(cardProvider)) {
+      tmpCardsArray.push(cards[cardProvider]);
+    }
+  }
+  return tmpCardsArray;
+})();
 
 export default function isCreditCard(card, options = {}) {
   assertString(card);
@@ -26,7 +33,7 @@ export default function isCreditCard(card, options = {}) {
   } else if (provider && !(provider.toLowerCase() in cards)) {
     /* specific provider not in the list */
     throw new Error(`${provider} is not a valid credit card provider.`);
-  } else if (!(allCards.test(sanitized))) {
+  } else if (!allCards.some(cardProvider => cardProvider.test(sanitized))) {
     // no specific provider
     return false;
   }


### PR DESCRIPTION
Hello,

I've refactored the way the `allCards` variable is created/handled in isCreditCard:
It currently is **manually** hardcoding all of the previously already defined RegExp into one huge RegExp, that it later then checks against.

This is problematic, because:
* it adds unnecessary code duplication (you need to store the provider RegExps in two places: 1x on its own and 1x inside `allCards`
* (at least to my eyes) it is unreadable
* therefore it makes it a nightmare to update RegExps or add new providers


I've replace it with a dynamically created array with the RegExps from the `cards` object instead, which will make it a lot easier to maintain and update, when new providers are added:
* you only need to add the RegExp inside the `cards` object
* no manual copying of the RegExp necessary


Since we are now working with an array instead of one huge RegExp, I had to also change the last "else if":
There I am using the [Array some() method](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/some), which checks if any of the items inside the array return true for a given function.

## Checklist

- [x] PR contains only changes related; no stray files, etc.
- ~~[ ] README updated (where applicable)~~
- ~~[ ] Tests written (where applicable)~~
