### PR TITLE
docs(CHANGELOG): remove duplicated "New Features" section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,6 @@
 
 - [#1706](https://github.com/validatorjs/validator.js/pull/1706) `isISO4217`, currency code validator @jpaya17
 
-### New Features
-
-- [#1706](https://github.com/validatorjs/validator.js/pull/1706) `isISO4217`, currency code validator @jpaya17
-
 ### Fixes and Enhancements
 
 - [#1647](https://github.com/validatorjs/validator.js/pull/1647) `isFQDN`: add `allow_wildcard` option @fasenderos


### PR DESCRIPTION
Remove duplicated section in CHANGELOG.md, which was listed twice for some reason:
```
### New Features

- [#1706](https://github.com/validatorjs/validator.js/pull/1706) `isISO4217`, currency code validator @jpaya17
```

## Checklist

- [x] PR contains only changes related; no stray files, etc.
- ~~[ ] README updated (where applicable)~~
- ~~[ ] Tests written (where applicable)~~
