### PR TITLE
fix(isMimeType): Fix MIME Types with underscores not getting matched

### DIFF
--- a/src/lib/isMimeType.js
+++ b/src/lib/isMimeType.js
@@ -26,7 +26,7 @@ import assertString from './util/assertString';
 // NB :
 //   Subtype length must not exceed 100 characters.
 //   This rule does not comply to the RFC specs (what is the max length ?).
-const mimeTypeSimple = /^(application|audio|font|image|message|model|multipart|text|video)\/[a-zA-Z0-9\.\-\+]{1,100}$/i; // eslint-disable-line max-len
+const mimeTypeSimple = /^(application|audio|font|image|message|model|multipart|text|video)\/[a-zA-Z0-9\.\-\+_]{1,100}$/i; // eslint-disable-line max-len
 
 // Handle "charset" in "text/*"
 const mimeTypeText = /^text\/[a-zA-Z0-9\.\-\+]{1,100};\s?charset=("[a-zA-Z0-9\.\-\+\s]{0,70}"|[a-zA-Z0-9\.\-\+]{0,70})(\s?\([a-zA-Z0-9\.\-\+\s]{1,20}\))?$/i; // eslint-disable-line max-len

--- a/test/validators.test.js
+++ b/test/validators.test.js
@@ -11809,6 +11809,7 @@ describe('Validators', () => {
         'font/woff2',
         'message/http',
         'model/vnd.gtw',
+        'application/media_control+xml',
         'multipart/form-data',
         'multipart/form-data; boundary=something',
         'multipart/form-data; charset=utf-8; boundary=something',


### PR DESCRIPTION
Add `_` (underscore) to the `mimeTypeSimple` RegExp to fix valid MIME types not getting matched.
Kindly check #2119  for more details

This fixes #2119

## Checklist

- [x] PR contains only changes related; no stray files, etc.
- ~~[ ] README updated (where applicable)~~
- [x] Tests written (where applicable)
