### PR TITLE
build(devDeps): Update rollup and babel to latest packages

### DIFF
--- a/build-browser.js
+++ b/build-browser.js
@@ -1,24 +1,25 @@
 /* eslint import/no-extraneous-dependencies: 0 */
 import fs from "fs";
 import { rollup } from "rollup";
-import babel from "rollup-plugin-babel";
+import babel from "@rollup/plugin-babel";
 import babelPresetEnv from "@babel/preset-env";
 import pkg from "./package.json";
 
 rollup({
-  entry: "src/index.js",
+  input: "src/index.js",
   plugins: [
     babel({
       presets: [[babelPresetEnv, { modules: false }]],
       babelrc: false,
+      babelHelpers: "bundled",
     }),
   ],
 })
   .then((bundle) =>
     bundle.write({
-      dest: "validator.js",
+      file: "validator.js",
       format: "umd",
-      moduleName: pkg.name,
+      name: pkg.name,
       banner: `/*!\n${String(fs.readFileSync("./LICENSE"))
         .trim()
         .split("\n")

--- a/package.json
+++ b/package.json
@@ -36,22 +36,22 @@
     "url": "git+https://github.com/validatorjs/validator.js.git"
   },
   "devDependencies": {
-    "@babel/cli": "^7.0.0",
-    "@babel/core": "^7.0.0",
-    "@babel/preset-env": "^7.0.0",
-    "@babel/register": "^7.0.0",
-    "babel-eslint": "^10.0.1",
-    "babel-plugin-add-module-exports": "^1.0.0",
+    "@babel/cli": "^7.19.3",
+    "@babel/core": "^7.20.5",
+    "@babel/preset-env": "^7.20.2",
+    "@babel/register": "^7.18.9",
+    "babel-eslint": "^10.1.0",
+    "babel-plugin-add-module-exports": "^1.0.4",
     "eslint": "^4.19.1",
     "eslint-config-airbnb-base": "^12.1.0",
     "eslint-plugin-import": "^2.11.0",
     "mocha": "^6.2.3",
     "npm-run-all": "^4.1.5",
-    "nyc": "^14.1.0",
-    "rimraf": "^3.0.0",
-    "rollup": "^0.47.0",
-    "rollup-plugin-babel": "^4.0.1",
-    "uglify-js": "^3.0.19"
+    "nyc": "^15.1.0",
+    "rimraf": "^3.0.2",
+    "rollup": "^3.7.5",
+    "@rollup/plugin-babel": "^6.0.3",
+    "uglify-js": "^3.17.4"
   },
   "scripts": {
     "lint": "eslint src test",


### PR DESCRIPTION
I've updated the devDependencies in package.json to the latest version, where possible.

This also made some changes necessary in the `browser-build.js`, as a few of the options have been renamed since v0.48
https://gist.github.com/Rich-Harris/d472c50732dab03efeb37472b08a3f32


I skipped updating `eslint`, as they are dropping Node 6 support since v5, while this project seems to still want to have support for Node 6, so for now we are stuck with eslint v4.

Fixes #2123 
## Checklist

- [x] PR contains only changes related; no stray files, etc.
- ~~[ ] README updated (where applicable)~~
- ~~[ ] Tests written (where applicable)~~
