### PR TITLE
Validator does not recognise £ as symbol

### DIFF
--- a/src/lib/isStrongPassword.js
+++ b/src/lib/isStrongPassword.js
@@ -4,7 +4,7 @@ import assertString from './util/assertString';
 const upperCaseRegex = /^[A-Z]$/;
 const lowerCaseRegex = /^[a-z]$/;
 const numberRegex = /^[0-9]$/;
-const symbolRegex = /^[-#!$@%^&*()_+|~=`{}\[\]:";'<>?,.\/ ]$/;
+const symbolRegex = /^[-#!$@£%^&*()_+|~=`{}\[\]:";'<>?,.\/ ]$/;
 
 const defaultOptions = {
   minLength: 8,

--- a/test/validators.js
+++ b/test/validators.js
@@ -12425,6 +12425,7 @@ describe('Validators', () => {
         'mxH_+2vs&54_+H3P',
         '+&DxJ=X7-4L8jRCD',
         'etV*p%Nr6w&H%FeF',
+        '£3.ndSau_7',
       ],
       invalid: [
         '',


### PR DESCRIPTION
Add £ to symbolRegex, for isStrongPassword.

Sorry for creating a double PR, but noticed that PR hadn't been touched in 5 days