### PR TITLE
feat(isEmail): Disallow emails starting with but not ending with quote

### DIFF
--- a/src/lib/isEmail.js
+++ b/src/lib/isEmail.js
@@ -160,7 +160,7 @@ export default function isEmail(str, options) {
     }
   }
 
-  if (user[0] === '"') {
+  if (user[0] === '"' && user[user.length - 1] === '"') {
     user = user.slice(1, user.length - 1);
     return options.allow_utf8_local_part ?
       quotedEmailUserUtf8.test(user) :

--- a/test/validators.test.js
+++ b/test/validators.test.js
@@ -32,6 +32,7 @@ describe('Validators', () => {
         'test@1337.com',
       ],
       invalid: [
+        '"invalid@gmail.com',
         'invalidemail@',
         'invalid.com',
         '@invalid.com',


### PR DESCRIPTION
<!--
Add a descriptive title textbox above, e.g.
feat(validatorName): brief title of what has been done
-->

<!--- briefly describe what you have done in this PR --->
I have invalidated all emails where the user part begins with a quotation but does not end with a quotation. Solves #2184

For example, these are invalid emails:
`"example@email.com`
`"<example@email.com`
`" example@email.com`

<!--- provide some (credible) references showing the structure of the data to be validated, if applicable --->

Reference:
"spaces, quotes, and backslashes may only exist when within quoted strings and preceded by a backslash" ~https://en.wikipedia.org/wiki/Email_address#Examples


## Checklist

- [x] PR contains only changes related; no stray files, etc.
- [ ] README updated (where applicable)
- [x] Tests written (where applicable)
- [x] References provided in PR (where applicable)
