### PR TITLE
feat: support `XK` in `isISO31661Alpha2()`

### DIFF
--- a/src/lib/isBIC.js
+++ b/src/lib/isBIC.js
@@ -11,7 +11,7 @@ export default function isBIC(str) {
   // the regex to [A-Z] (per the spec).
   const countryCode = str.slice(4, 6).toUpperCase();
 
-  if (!CountryCodes.has(countryCode) && countryCode !== 'XK') {
+  if (!CountryCodes.has(countryCode)) {
     return false;
   }
 

--- a/src/lib/isISO31661Alpha2.js
+++ b/src/lib/isISO31661Alpha2.js
@@ -24,6 +24,7 @@ const validISO31661Alpha2CountriesCodes = new Set([
   'TC', 'TD', 'TF', 'TG', 'TH', 'TJ', 'TK', 'TL', 'TM', 'TN', 'TO', 'TR', 'TT', 'TV', 'TW', 'TZ',
   'UA', 'UG', 'UM', 'US', 'UY', 'UZ',
   'VA', 'VC', 'VE', 'VG', 'VI', 'VN', 'VU',
+  'XK',
   'WF', 'WS',
   'YE', 'YT',
   'ZA', 'ZM', 'ZW',


### PR DESCRIPTION
This adds Kosovo support for isISO31661Alpha2 check.

https://laendercode.net/en/2-letter-code/xk

## Checklist

- [x] PR contains only changes related; no stray files, etc.
- [ ] README updated (where applicable)
- [ ] Tests written (where applicable)
- [ ] References provided in PR (where applicable)
