### PR TITLE
 Fix validation issue in isJWT function

### DIFF
--- a/src/lib/isJWT.js
+++ b/src/lib/isJWT.js
@@ -7,7 +7,7 @@ export default function isJWT(str) {
   const dotSplit = str.split('.');
   const len = dotSplit.length;
 
-  if (len > 3 || len < 2) {
+  if (len !== 3) {
     return false;
   }
 

--- a/test/validators.test.js
+++ b/test/validators.test.js
@@ -12,16 +12,15 @@ describe('Validators', () => {
     test({
       validator: 'isJWT',
       valid: [
-        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c', 
-        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjY0MzgzYjNlYzMzZWUzOWMwZjY4ODVjYiIsInVzZXJJZCI6ImFkbWluIiwicm9sZSI6IkFETUlOIiwiaWF0IjoxNjgxNDA2ODI5LCJleHAiOjE2ODE0OTMyMjl9.a6b5feVNetyVaA7sk5YQrJSuvikO7uWIMQaUT7K_1gI', 
+        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c',
+        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjY0MzgzYjNlYzMzZWUzOWMwZjY4ODVjYiIsInVzZXJJZCI6ImFkbWluIiwicm9sZSI6IkFETUlOIiwiaWF0IjoxNjgxNDA2ODI5LCJleHAiOjE2ODE0OTMyMjl9.a6b5feVNetyVaA7sk5YQrJSuvikO7uWIMQaUT7K_1gI',
       ],
       invalid: [
         'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9',
-        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ', 
+        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ',
       ],
     });
   });
-
   it('should validate email addresses', () => {
     test({
       validator: 'isEmail',

--- a/test/validators.test.js
+++ b/test/validators.test.js
@@ -4681,7 +4681,6 @@ describe('Validators', () => {
         'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NSIsIm5hbWUiOiJKb2huIERvZSIsImlhdCI6MTYxNjY1Mzg3Mn0.eyJpc3MiOiJodHRwczovL2V4YW1wbGUuY29tIiwiaWF0IjoxNjE2NjUzODcyLCJleHAiOjE2MTY2NTM4ODJ9.a1jLRQkO5TV5y5ERcaPAiM9Xm2gBdRjKrrCpHkGr_8M',
         '$Zs.ewu.su84',
         'ks64$S/9.dy$§kz.3sd73b',
-        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ',
       ],
       error: [
         [],

--- a/test/validators.test.js
+++ b/test/validators.test.js
@@ -8,6 +8,20 @@ import test from './testFunctions';
 let validator_js = fs.readFileSync(require.resolve('../validator.js')).toString();
 
 describe('Validators', () => {
+  it('should validate JSON web tokens (JWT)', () => {
+    test({
+      validator: 'isJWT',
+      valid: [
+        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c', 
+        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjY0MzgzYjNlYzMzZWUzOWMwZjY4ODVjYiIsInVzZXJJZCI6ImFkbWluIiwicm9sZSI6IkFETUlOIiwiaWF0IjoxNjgxNDA2ODI5LCJleHAiOjE2ODE0OTMyMjl9.a6b5feVNetyVaA7sk5YQrJSuvikO7uWIMQaUT7K_1gI', 
+      ],
+      invalid: [
+        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9',
+        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ', 
+      ],
+    });
+  });
+
   it('should validate email addresses', () => {
     test({
       validator: 'isEmail',

--- a/test/validators.test.js
+++ b/test/validators.test.js
@@ -8,19 +8,6 @@ import test from './testFunctions';
 let validator_js = fs.readFileSync(require.resolve('../validator.js')).toString();
 
 describe('Validators', () => {
-  it('should validate JSON web tokens (JWT)', () => {
-    test({
-      validator: 'isJWT',
-      valid: [
-        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c',
-        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjY0MzgzYjNlYzMzZWUzOWMwZjY4ODVjYiIsInVzZXJJZCI6ImFkbWluIiwicm9sZSI6IkFETUlOIiwiaWF0IjoxNjgxNDA2ODI5LCJleHAiOjE2ODE0OTMyMjl9.a6b5feVNetyVaA7sk5YQrJSuvikO7uWIMQaUT7K_1gI',
-      ],
-      invalid: [
-        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9',
-        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ',
-      ],
-    });
-  });
   it('should validate email addresses', () => {
     test({
       validator: 'isEmail',
@@ -4687,12 +4674,14 @@ describe('Validators', () => {
         'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJsb3JlbSI6Imlwc3VtIn0.ymiJSsMJXR6tMSr8G9usjQ15_8hKPDv_CArLhxw28MI',
         'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJkb2xvciI6InNpdCIsImFtZXQiOlsibG9yZW0iLCJpcHN1bSJdfQ.rRpe04zbWbbJjwM43VnHzAboDzszJtGrNsUxaqQ-GQ8',
         'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqb2huIjp7ImFnZSI6MjUsImhlaWdodCI6MTg1fSwiamFrZSI6eyJhZ2UiOjMwLCJoZWlnaHQiOjI3MH19.YRLPARDmhGMC3BBk_OhtwwK21PIkVCqQe8ncIRPKo-E',
-        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ', // No signature
       ],
       invalid: [
         'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9',
+        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NSIsIm5hbWUiOiJKb2huIERvZSIsImlhdCI6MTUxNjIzOTAyMn0',
+        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NSIsIm5hbWUiOiJKb2huIERvZSIsImlhdCI6MTYxNjY1Mzg3Mn0.eyJpc3MiOiJodHRwczovL2V4YW1wbGUuY29tIiwiaWF0IjoxNjE2NjUzODcyLCJleHAiOjE2MTY2NTM4ODJ9.a1jLRQkO5TV5y5ERcaPAiM9Xm2gBdRjKrrCpHkGr_8M',
         '$Zs.ewu.su84',
         'ks64$S/9.dy$§kz.3sd73b',
+        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ',
       ],
       error: [
         [],


### PR DESCRIPTION
This PR fixes the validation issue in the isJWT function where it was returning true for a 2-part invalid JWT token. The fix is to check for len < 3 instead of len < 2 in the code.

Changes Made:

Updated the validation check for len < 3 in isJWT function
Testing:

Ran unit tests for the isJWT function and verified that it now returns false for 2-part invalid JWT tokens.