### PR TITLE
fix(isDate): Timezone Offset Fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "rimraf": "^3.0.0",
     "rollup": "^0.47.0",
     "rollup-plugin-babel": "^4.0.1",
+    "timezone-mock": "^1.3.6",
     "uglify-js": "^3.0.19"
   },
   "scripts": {

--- a/src/lib/isDate.js
+++ b/src/lib/isDate.js
@@ -77,7 +77,7 @@ export default function isDate(input, options) {
       day = `0${dateObj.d}`;
     }
 
-    return new Date(`${fullYear}-${month}-${day}T00:00:00`).getDate() === +dateObj.d;
+    return new Date(`${fullYear}-${month}-${day}T00:00:00.000Z`).getUTCDate() === +dateObj.d;
   }
 
   if (!options.strictMode) {

--- a/src/lib/isDate.js
+++ b/src/lib/isDate.js
@@ -65,7 +65,19 @@ export default function isDate(input, options) {
       }
     }
 
-    return new Date(`${fullYear}-${dateObj.m}-${dateObj.d}`).getDate() === +dateObj.d;
+    let month = dateObj.m;
+
+    if (dateObj.m.length === 1) {
+      month = `0${dateObj.m}`;
+    }
+
+    let day = dateObj.d;
+
+    if (dateObj.d.length === 1) {
+      day = `0${dateObj.d}`;
+    }
+
+    return new Date(`${fullYear}-${month}-${day}T00:00:00`).getDate() === +dateObj.d;
   }
 
   if (!options.strictMode) {

--- a/test/validators.test.js
+++ b/test/validators.test.js
@@ -13061,8 +13061,8 @@ describe('Validators', () => {
     test({
       validator: 'isDate',
       valid: [
-        new Date(),
-        '2023-08-04',
+        new Date(2016, 2, 29),
+        '2017-08-04',
       ],
     });
     timezone_mock.unregister();

--- a/test/validators.test.js
+++ b/test/validators.test.js
@@ -1,5 +1,6 @@
 import assert from 'assert';
 import fs from 'fs';
+import timezone_mock from 'timezone-mock';
 import { format } from 'util';
 import vm from 'vm';
 import validator from '../src/index';
@@ -13054,6 +13055,17 @@ describe('Validators', () => {
         '29.02.2020',
       ],
     });
+    // emulating Pacific time zone offset & time
+    // which could potentially result in UTC conversion issues
+    timezone_mock.register('US/Pacific');
+    test({
+      validator: 'isDate',
+      valid: [
+        new Date(),
+        '2023-08-04',
+      ],
+    });
+    timezone_mock.unregister();
   });
   it('should validate time', () => {
     test({


### PR DESCRIPTION
This pull request resolves issues with false negatives when using the `isDate` validator (Issue #2256). When parsing dates, the `YYYY-MM-DD` date format gets interpreted to be in the UTC time zone ([MDN Docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/parse#using_date.parse)), while the `getDate()` method outputs the day of the month in the current time zone ([MDN Docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getDate)). This apples-to-oranges comparison can result in occasional discrepancies, depending on the user's local time and timezone.

This PR appends `T00:00:00` time information into the parsed string (as suggested by @brunoabude). That will cause the  date string to be interpreted in the local time zone. Additionally, I added leading zeros for months and days (where applicable) to ensure that date strings always follow the ISO 8601 format (as intended in #2231).

## Checklist

- [X] PR contains only changes related; no stray files, etc.
- [X] README updated (where applicable)
- [X] Tests written (where applicable)
- [X] References provided in PR (where applicable)
