### PR TITLE
regex for country code PT #2195

### DIFF
--- a/src/lib/isPassportNumber.js
+++ b/src/lib/isPassportNumber.js
@@ -56,7 +56,7 @@ const passportRegexByCountryCode = {
   PH: /^([A-Z](\d{6}|\d{7}[A-Z]))|([A-Z]{2}(\d{6}|\d{7}))$/, // PHILIPPINES
   PK: /^[A-Z]{2}\d{7}$/, // PAKISTAN
   PL: /^[A-Z]{2}\d{7}$/, // POLAND
-  PT: /^[A-Z]\d{6}$/, // PORTUGAL
+  PT: /^[A-Z]{1,2}\d{6}$/, // PORTUGAL
   RO: /^\d{8,9}$/, // ROMANIA
   RU: /^\d{9}$/, // RUSSIAN FEDERATION
   SE: /^\d{8}$/, // SWEDEN


### PR DESCRIPTION



![Screenshot (313)](https://github.com/validatorjs/validator.js/assets/108010466/7c7e1030-9296-43fb-a5d2-235d5b99660a)
I have made bug fix in regex pattern in line no.59 for country code PT(Portugal) since country code for PT has changed after 2018 A.D.