### PR TITLE
fix(isPostalCode): Improve Dutch postal code regex

### DIFF
--- a/src/lib/isPostalCode.js
+++ b/src/lib/isPostalCode.js
@@ -52,7 +52,7 @@ const patterns = {
   MX: fiveDigit,
   MT: /^[A-Za-z]{3}\s{0,1}\d{4}$/,
   MY: fiveDigit,
-  NL: /^\d{4}\s?[a-z]{2}$/i,
+  NL: /^[1-9]\d{3}\s?(?!sa|sd|ss)[a-z]{2}$/i,
   NO: fourDigit,
   NP: /^(10|21|22|32|33|34|44|45|56|57)\d{3}$|^(977)$/i,
   NZ: fourDigit,

--- a/test/validators.test.js
+++ b/test/validators.test.js
@@ -11860,6 +11860,13 @@ describe('Validators', () => {
           '3950IO',
           '3997 GH',
         ],
+        invalid: [
+          '1234',
+          '0603 JV',
+          '5194SA',
+          '9164 SD',
+          '1841SS',
+        ],
       },
       {
         locale: 'NP',


### PR DESCRIPTION
I have improved the regular expression for postal codes of the Netherlands. They cannot start with a zero, and they cannot contain "SA", "SD" and "SS".

More information: https://en.wikipedia.org/wiki/Postal_codes_in_the_Netherlands