### PR TITLE
fix(isDate):breaks on 2 digit strings (#2272)

### DIFF
--- a/src/lib/isDate.js
+++ b/src/lib/isDate.js
@@ -49,7 +49,7 @@ export default function isDate(input, options) {
 
     let fullYear = dateObj.y;
 
-    if (dateObj.y.length === 2) {
+    if (dateObj.y?.length === 2) {
       const parsedYear = parseInt(dateObj.y, 10);
 
       if (isNaN(parsedYear)) {
@@ -67,13 +67,13 @@ export default function isDate(input, options) {
 
     let month = dateObj.m;
 
-    if (dateObj.m.length === 1) {
+    if (dateObj.m?.length === 1) {
       month = `0${dateObj.m}`;
     }
 
     let day = dateObj.d;
 
-    if (dateObj.d.length === 1) {
+    if (dateObj.d?.length === 1) {
       day = `0${dateObj.d}`;
     }
 

--- a/test/validators.test.js
+++ b/test/validators.test.js
@@ -13095,6 +13095,26 @@ describe('Validators', () => {
         '29.02.2020',
       ],
     });
+    test({
+      validator: 'isDate',
+      args: [{ format: 'DD/MM/YY' }],
+      valid: [
+        '15-07-02',
+        '15/07/02',
+        '12/11/28',
+      ],
+      invalid: [
+        '7',
+        '4.5',
+        '78',
+        '17',
+        '20',
+        '15/7/2002',
+        '15-7-2002',
+        '15/07-02',
+        '30/04/--',
+      ],
+    });
     // emulating Pacific time zone offset & time
     // which could potentially result in UTC conversion issues
     timezone_mock.register('US/Pacific');


### PR DESCRIPTION
fix(isDate):throws error rather than return false on 2 digit strings 

as described in this issue #2272, version 13.11 introduced an issue where trying to validate an invalid date string throws an error rather than returning false. 
The error occurs due to the way the dateObj is being handled. Specifically, when the input is a 2-digit number, the property dateObj.y becomes undefined, causing the length check to throw a TypeError.

## Checklist

- [ x] PR contains only changes related; no stray files, etc.
- [x ] README updated (where applicable)
- [x ] Tests written (where applicable)
- [ x] References provided in PR (where applicable)
