### PR TITLE
chore: Publish to NPM with provenance

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -9,14 +9,14 @@ jobs:
       contents: read
       id-token: write
     steps:
-    - name: Setup Node.js 14
-      uses: actions/setup-node@v2-beta
+    - name: Setup Node.js 18
+      uses: actions/setup-node@v3
       with:
-        node-version: 14
+        node-version: 18
         check-latest: true
         registry-url: https://registry.npmjs.org/
     - name: Checkout Repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Install Dependencies
       run: npm install
     - name: Run Tests

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -5,6 +5,9 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-20.04
+    permissions:
+      contents: read
+      id-token: write
     steps:
     - name: Setup Node.js 14
       uses: actions/setup-node@v2-beta
@@ -19,6 +22,6 @@ jobs:
     - name: Run Tests
       run: npm test
     - name: Publish Package to NPM Registry
-      run: npm publish
+      run: npm publish --provenance
       env:
         NODE_AUTH_TOKEN: ${{secrets.NPM_SECRET}}


### PR DESCRIPTION
chore: Publish to NPM with provenance

<!--
Add a descriptive title textbox above, e.g.
feat(validatorName): brief title of what has been done
-->

<!--- briefly describe what you have done in this PR --->

The release process in this repository is already automated via GitHub Actions, which is a great first step toward creating trust in the supply chain. Recently, NPM has started to support publishing with the `--provenance` flag. This flag creates a link between the GitHub Actions run that created the release and the final artifact on NPM. This linkage further ensures that package installs can be traced back to a specific code revision.

For more information on publishing with provenance, please refer to: https://github.blog/2023-04-19-introducing-npm-package-provenance/

Note that the update of Node.js to v18 is required for NPM v9.5+ to be installed, which is needed for provenance.

<!--- provide some (credible) references showing the structure of the data to be validated, if applicable --->

## Checklist

- [X] PR contains only changes related; no stray files, etc.
- [ ] README updated (where applicable)
- [ ] Tests written (where applicable)
- [X] References provided in PR (where applicable)
