### PR TITLE
AZ regex fix

### DIFF
--- a/src/lib/isPassportNumber.js
+++ b/src/lib/isPassportNumber.js
@@ -11,7 +11,7 @@ const passportRegexByCountryCode = {
   AR: /^[A-Z]{3}\d{6}$/, // ARGENTINA
   AT: /^[A-Z]\d{7}$/, // AUSTRIA
   AU: /^[A-Z]\d{7}$/, // AUSTRALIA
-  AZ: /^[A-Z]{2,3}\d{7,8}$/, // AZERBAIJAN
+  AZ: /^[A-Z]{1}\d{8}$/, // AZERBAIJAN
   BE: /^[A-Z]{2}\d{6}$/, // BELGIUM
   BG: /^\d{9}$/, // BULGARIA
   BR: /^[A-Z]{2}\d{6}$/, // BRAZIL


### PR DESCRIPTION
fix(isPassportNumber): regex fix for Azerbaijan
<!--
Add a descriptive title textbox above, e.g.
feat(validatorName): brief title of what has been done
-->
Fixed regex for Azerbaijan isPassportNumber
<!--- briefly describe what you have done in this PR --->
https://irb.gc.ca/en/country-information/rir/Pages/index.aspx?doc=455354&pls=1
"According to Keesing, the passport number is 8 digits preceded by a letter (ibid.)"
<!--- provide some (credible) references showing the structure of the data to be validated, if applicable --->

## Checklist

- [x] PR contains only changes related; no stray files, etc.
- [ ] README updated (where applicable)
- [ ] Tests written (where applicable)
- [x] References provided in PR (where applicable)