### PR TITLE
fix(isMail):fixed consecutive hyphen check in domain part

### DIFF
--- a/src/lib/isFQDN.js
+++ b/src/lib/isFQDN.js
@@ -8,6 +8,7 @@ const default_fqdn_options = {
   allow_numeric_tld: false,
   allow_wildcard: false,
   ignore_max_length: false,
+  disallow_consecutive_hyphens: true,
 };
 
 export default function isFQDN(str, options) {
@@ -17,6 +18,11 @@ export default function isFQDN(str, options) {
   /* Remove the optional trailing dot before checking validity */
   if (options.allow_trailing_dot && str[str.length - 1] === '.') {
     str = str.substring(0, str.length - 1);
+  }
+
+  /* Check for consecutive hyphens in the domain part */
+  if (options.disallow_consecutive_hyphens && /--/.test(str)) {
+    return false;
   }
 
   /* Remove the optional wildcard before checking validity */


### PR DESCRIPTION
When doing check with isEmail('test@gma--il.com'), now returns false and behaves as expected. Fix based on suggestion by [itbali](https://github.com/itbali)

Fixes #2268

<!--
Add a descriptive title textbox above, e.g.
feat(validatorName): brief title of what has been done
-->

<!--- briefly describe what you have done in this PR --->

<!--- provide some (credible) references showing the structure of the data to be validated, if applicable --->

## Checklist

- [ ] PR contains only changes related; no stray files, etc.
- [ ] README updated (where applicable)
![image](https://github.com/validatorjs/validator.js/assets/95236968/0da1b853-eb43-4fcd-b7e9-223cf7801131)

- [ ] Tests written (where applicable)
- [ ] References provided in PR (where applicable)
