### PR TITLE
Handle null/undefined options for isInt and isFloat

### DIFF
--- a/src/lib/isFloat.js
+++ b/src/lib/isFloat.js
@@ -10,10 +10,10 @@ export default function isFloat(str, options) {
   }
   const value = parseFloat(str.replace(',', '.'));
   return float.test(str) &&
-    (!options.hasOwnProperty('min') || value >= options.min) &&
-    (!options.hasOwnProperty('max') || value <= options.max) &&
-    (!options.hasOwnProperty('lt') || value < options.lt) &&
-    (!options.hasOwnProperty('gt') || value > options.gt);
+    (!options.hasOwnProperty('min') || options.min === undefined || options.min === null || value >= options.min) &&
+    (!options.hasOwnProperty('max') || options.max === undefined || options.max === null || value <= options.max) &&
+    (!options.hasOwnProperty('lt') || options.lt === undefined || options.lt === null || value < options.lt) &&
+    (!options.hasOwnProperty('gt') || options.gt === undefined || options.gt === null || value > options.gt);
 }
 
 export const locales = Object.keys(decimal);

--- a/src/lib/isInt.js
+++ b/src/lib/isInt.js
@@ -15,10 +15,10 @@ export default function isInt(str, options) {
   );
 
   // Check min/max/lt/gt
-  let minCheckPassed = (!options.hasOwnProperty('min') || str >= options.min);
-  let maxCheckPassed = (!options.hasOwnProperty('max') || str <= options.max);
-  let ltCheckPassed = (!options.hasOwnProperty('lt') || str < options.lt);
-  let gtCheckPassed = (!options.hasOwnProperty('gt') || str > options.gt);
+  let minCheckPassed = (!options.hasOwnProperty('min') || options.min === undefined || options.min === null || str >= options.min);
+  let maxCheckPassed = (!options.hasOwnProperty('max') || options.max === undefined || options.max === null || str <= options.max);
+  let ltCheckPassed = (!options.hasOwnProperty('lt') || options.lt === undefined || options.lt === null || str < options.lt);
+  let gtCheckPassed = (!options.hasOwnProperty('gt') || options.gt === undefined || options.gt === null || str > options.gt);
 
   return regex.test(str) && minCheckPassed && maxCheckPassed && ltCheckPassed && gtCheckPassed;
 }

--- a/test/validators.test.js
+++ b/test/validators.test.js
@@ -4191,6 +4191,42 @@ describe('Validators', () => {
         'c21',
       ],
     });
+    test({
+      validator: 'isInt',
+      args: [{
+        gt: null,
+        max: null,
+      }],
+      valid: [
+        '1',
+        '886',
+        '84512345',
+      ],
+      invalid: [
+        '10.4',
+        'h',
+        '1.2',
+        '+',
+      ],
+    });
+    test({
+      validator: 'isInt',
+      args: [{
+        lt: null,
+        min: null,
+      }],
+      valid: [
+        '289373466',
+        '55',
+        '989',
+      ],
+      invalid: [
+        ',',
+        '+11212+',
+        'fail',
+        '111987234i',
+      ],
+    });
   });
 
   it('should validate floats', () => {
@@ -4458,6 +4494,47 @@ describe('Validators', () => {
         '-,123',
         '+,123',
         '7866.t',
+      ],
+    });
+    test({
+      validator: 'isFloat',
+      args: [{
+        locale: 'ar',
+        gt: null,
+        max: null,
+      }],
+      valid: [
+        '13324٫',
+        '12321',
+        '444٫83874',
+      ],
+      invalid: [
+        '55.55.55',
+        '1;23',
+        '+-123',
+        '1111111l1',
+        '3.3',
+      ],
+    });
+    test({
+      validator: 'isFloat',
+      args: [{
+        locale: 'ru-RU',
+        lt: null,
+        min: null,
+      }],
+      valid: [
+        '11231554,34343',
+        '11,1',
+        '456',
+        ',311',
+      ],
+      invalid: [
+        'ab565',
+        '-.123',
+        '+.123',
+        '7866.t',
+        '22.3',
       ],
     });
   });

--- a/test/validators.test.js
+++ b/test/validators.test.js
@@ -4155,6 +4155,42 @@ describe('Validators', () => {
         'a',
       ],
     });
+    test({
+      validator: 'isInt',
+      args: [{
+        min: undefined,
+        max: undefined,
+      }],
+      valid: [
+        '143',
+        '15',
+        '767777575',
+      ],
+      invalid: [
+        '10.4',
+        'bar',
+        '10a',
+        'c44',
+      ],
+    });
+    test({
+      validator: 'isInt',
+      args: [{
+        gt: undefined,
+        lt: undefined,
+      }],
+      valid: [
+        '289373466',
+        '55',
+        '989',
+      ],
+      invalid: [
+        '10.4',
+        'baz',
+        '66a',
+        'c21',
+      ],
+    });
   });
 
   it('should validate floats', () => {
@@ -4382,6 +4418,46 @@ describe('Validators', () => {
         '',
         '.',
         'foo',
+      ],
+    });
+    test({
+      validator: 'isFloat',
+      args: [{
+        min: undefined,
+        max: undefined,
+      }],
+      valid: [
+        '123',
+        '123.',
+        '123.123',
+        '-767.767',
+        '+111.111',
+      ],
+      invalid: [
+        'ab565',
+        '-,123',
+        '+,123',
+        '7866.t',
+        '123,123',
+        '123,',
+      ],
+    });
+    test({
+      validator: 'isFloat',
+      args: [{
+        gt: undefined,
+        lt: undefined,
+      }],
+      valid: [
+        '14.34343',
+        '11.1',
+        '456',
+      ],
+      invalid: [
+        'ab565',
+        '-,123',
+        '+,123',
+        '7866.t',
       ],
     });
   });


### PR DESCRIPTION
## What has been modified

Bug(isInt): Returns true in case an option was passed as null/undefined for that specific condition
Bug(isFloat): Returns true in case an option was passed as null/undefined for that specific condition


## What has been done

Added checks for null and undefined in both functions `isInt` and `isFloat` to be able to handle cases of null/undefined

Old code example:
```javascript
isInt("5", {min: undefined, max: null}) // => false
isInt("5", {gt: null, lt: undefined}) // => false

isFloat("5.5", {min: null, max: undefined}) // => false
isFloat("5.5", {gt: undefined, lt: null}) // => false
```

Updated (New) code example:
```javascript
isInt("5", {min: undefined, max: null}) // => true
isInt("5", {gt: null, lt: undefined}) // => true

isFloat("5.5", {min: null, max: undefined}) // => true
isFloat("5.5", {gt: undefined, lt: null}) // => true
```

## Issue Referenced

[#2328 ](https://github.com/validatorjs/validator.js/issues/2328)

## Checklist

- [x] PR contains only changes related; no stray files, etc.
- [ ] README updated (where applicable)
- [x] Tests written (where applicable)
- [ ] References provided in PR (where applicable)
