### PR TITLE
fix: Spanish VAT number for foreigners

### DIFF
--- a/src/lib/isVAT.js
+++ b/src/lib/isVAT.js
@@ -60,7 +60,7 @@ export const vatMatchers = {
   RO: str => /^(RO)?\d{2,10}$/.test(str),
   SK: str => /^(SK)?\d{10}$/.test(str),
   SI: str => /^(SI)?\d{8}$/.test(str),
-  ES: str => /^(ES)?\w\d{7}[A-Z]$/.test(str),
+  ES: str => /^(ES)?(\d{8}|[a-zA-Z]\d{7}[0-9a-zA-Z])/.test(str),
   SE: str => /^(SE)?\d{12}$/.test(str),
 
   /**


### PR DESCRIPTION
This allows Spanish VAT numbers to have the following formats:
* ES12345678 (spanish people)
* ESX2345678X (foreigners)
* ESX23456789 (foreigners)

<!--
Add a descriptive title textbox above, e.g.
feat(validatorName): brief title of what has been done
-->

<!--- briefly describe what you have done in this PR --->

<!--- provide some (credible) references showing the structure of the data to be validated, if applicable --->

## Checklist

- [ ] PR contains only changes related; no stray files, etc.
- [ ] README updated (where applicable)
- [ ] Tests written (where applicable)
- [ ] References provided in PR (where applicable)
