### PR TITLE
Disallowing periods in slugs (Response to issue#2383)

### DIFF
--- a/src/lib/isSlug.js
+++ b/src/lib/isSlug.js
@@ -1,7 +1,6 @@
 import assertString from './util/assertString';
 
-let charsetRegex = /^(?![-_])^[^\s](?!.*?[-_]{2,})[a-z0-9*&\\]*(?:[-_][a-z0-9*&\\]+)*[^-_\s](?!\.)$/;
-// /^(?!.*\.)[^\s-_][a-z0-9-\\][^\s]*[^-_\s]$/
+let charsetRegex = /^(?!.*(?:-|_){2,})(?![-_])(?!.*(?:-|_)$)[a-z0-9*&\\]*(?:[-_][a-z0-9*&\\]+)*$/;
 
 export default function isSlug(str) {
   assertString(str);

--- a/src/lib/isSlug.js
+++ b/src/lib/isSlug.js
@@ -1,6 +1,7 @@
 import assertString from './util/assertString';
 
-let charsetRegex = /^(?!.*\.)[^\s-_][a-z0-9-\\][^\s]*[^-_\s]$/;
+let charsetRegex = /^(?![-_])^[^\s](?!.*?[-_]{2,})[a-z0-9*&\\]*(?:[-_][a-z0-9*&\\]+)*[^-_\s](?!\.)$/;
+// /^(?!.*\.)[^\s-_][a-z0-9-\\][^\s]*[^-_\s]$/
 
 export default function isSlug(str) {
   assertString(str);

--- a/src/lib/isSlug.js
+++ b/src/lib/isSlug.js
@@ -1,6 +1,6 @@
 import assertString from './util/assertString';
 
-let charsetRegex = /^[^\s-_](?!.*?[-_]{2,})[a-z0-9-\\][^\s]*[^-_\s]$/;
+let charsetRegex = /^(?!.*\.)[^\s-_][a-z0-9-\\][^\s]*[^-_\s]$/;
 
 export default function isSlug(str) {
   assertString(str);

--- a/test/validators.test.js
+++ b/test/validators.test.js
@@ -12855,6 +12855,7 @@ describe('Validators', () => {
     test({
       validator: 'isSlug',
       valid: [
+        'f-f',
         'foo',
         'foo-bar',
         'foo_bar',

--- a/test/validators.test.js
+++ b/test/validators.test.js
@@ -12865,6 +12865,7 @@ describe('Validators', () => {
       ],
       invalid: [
         'not-----------slug',
+        'is.not.a.slug',
         '@#_$@',
         '-not-slug',
         'not-slug-',


### PR DESCRIPTION
I have updated the regular expression pattern in isSlug.js to disallow periods for strings of type slug. I have also ensured that the modification made does not impact all the correct conditions the existing pattern supports at present.

![test-results](https://github.com/validatorjs/validator.js/assets/144161260/72db45f3-f884-4636-a588-c3b67ebf5d6b)

## Checklist

- [ ] PR contains only changes related; no stray files, etc.
- [ ] README updated (where applicable)
- [ ] Tests written (where applicable)
- [ ] References provided in PR (where applicable)
