### PR TITLE
fix(isEmail): blacklist character check fix for #2392

### DIFF
--- a/src/lib/isEmail.js
+++ b/src/lib/isEmail.js
@@ -162,6 +162,10 @@ export default function isEmail(str, options) {
     }
   }
 
+  if (options.blacklisted_chars) {
+    if (user.search(new RegExp(`[${options.blacklisted_chars}]+`, 'g')) !== -1) return false;
+  }
+
   if (user[0] === '"') {
     user = user.slice(1, user.length - 1);
     return options.allow_utf8_local_part ?
@@ -177,9 +181,6 @@ export default function isEmail(str, options) {
     if (!pattern.test(user_parts[i])) {
       return false;
     }
-  }
-  if (options.blacklisted_chars) {
-    if (user.search(new RegExp(`[${options.blacklisted_chars}]+`, 'g')) !== -1) return false;
   }
 
   return true;

--- a/test/validators.test.js
+++ b/test/validators.test.js
@@ -265,12 +265,15 @@ describe('Validators', () => {
   it('should not validate email addresses with blacklisted chars in the name', () => {
     test({
       validator: 'isEmail',
-      args: [{ blacklisted_chars: 'abc' }],
+      args: [{ blacklisted_chars: 'abc"' }],
       valid: [
         'emil@gmail.com',
       ],
       invalid: [
         'email@gmail.com',
+        '"foobr"@example.com',
+        '" foo m端ller "@example.com',
+        '"foo\@br"@example.com',
       ],
     });
   });


### PR DESCRIPTION
Fixes the bug #2392 
Order of blacklist characters check should be done before allow_utf8_local_part check since, that could possibly be true ignoring blacklisted characters


Added Appropriate validations tests data

## Checklist
- [x] PR contains only changes related to isEmail.js file 
- [x] Tests written
