### PR TITLE
Fixes #2424

### DIFF
--- a/src/lib/isFQDN.js
+++ b/src/lib/isFQDN.js
@@ -8,6 +8,7 @@ const default_fqdn_options = {
   allow_numeric_tld: false,
   allow_wildcard: false,
   ignore_max_length: false,
+  accents: false, // Added this line to include the new option
 };
 
 export default function isFQDN(str, options) {
@@ -33,7 +34,11 @@ export default function isFQDN(str, options) {
       return false;
     }
 
-    if (!options.allow_numeric_tld && !/^([a-z\u00A1-\u00A8\u00AA-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]{2,}|xn[a-z0-9-]{2,})$/i.test(tld)) {
+    const tldPattern = options.accents 
+      ? /^([a-z\u00A1-\u00A8\u00AA-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEFÀ-ÿ]{2,}|xn[a-z0-9-]{2,})$/i 
+      : /^([a-z\u00A1-\u00A8\u00AA-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]{2,}|xn[a-z0-9-]{2,})$/i;
+      
+    if (!options.allow_numeric_tld && !tldPattern.test(tld)) {
       return false;
     }
 
@@ -53,7 +58,11 @@ export default function isFQDN(str, options) {
       return false;
     }
 
-    if (!/^[a-z_\u00a1-\uffff0-9-]+$/i.test(part)) {
+    const partPattern = options.accents 
+      ? /^[a-z_\u00a1-\uffffÀ-ÿ0-9-]+$/i 
+      : /^[a-z_\u00a1-\uffff0-9-]+$/i;
+      
+    if (!partPattern.test(part)) {
       return false;
     }
 

--- a/src/lib/isURL.js
+++ b/src/lib/isURL.js
@@ -1,5 +1,4 @@
 import assertString from './util/assertString';
-
 import isFQDN from './isFQDN';
 import isIP from './isIP';
 import merge from './util/merge';
@@ -14,9 +13,8 @@ require_host - if set as false isURL will not check if host is present in the UR
 require_port - if set as true isURL will check if port is present in the URL
 allow_protocol_relative_urls - if set as true protocol relative URLs will be allowed
 validate_length - if set as false isURL will skip string length validation (IE maximum is 2083)
-
+accents - if set as true isURL will accept URLs with accented characters in the hostname
 */
-
 
 const default_url_options = {
   protocols: ['http', 'https', 'ftp'],
@@ -31,6 +29,7 @@ const default_url_options = {
   allow_fragments: true,
   allow_query_components: true,
   validate_length: true,
+  accents: false, 
 };
 
 const wrapped_ipv6 = /^\[([^\]]+)\](?::([0-9]+))?$/;
@@ -47,6 +46,14 @@ function checkHost(host, matches) {
     }
   }
   return false;
+}
+
+function isValidHostname(hostname, options) {
+  if (options.accents) {
+    // Allow accented characters
+    return /^[a-zA-Z0-9\-\.À-ÿ]+$/.test(hostname);
+  }
+  return isFQDN(hostname, options) || isIP(hostname);
 }
 
 export default function isURL(url, options) {
@@ -157,7 +164,7 @@ export default function isURL(url, options) {
     return true;
   }
 
-  if (!isIP(host) && !isFQDN(host, options) && (!ipv6 || !isIP(ipv6, 6))) {
+  if (!isValidHostname(host, options) && (!ipv6 || !isIP(ipv6, 6))) {
     return false;
   }
 


### PR DESCRIPTION
Added accents: false in default options and 
made a function to check accents url if it is true




function isValidHostname(hostname, options) {
  if (options.accents) {
    // Allow accented characters
    return /^[a-zA-Z0-9\-\.À-ÿ]+$/.test(hostname);
  }
  return isFQDN(hostname, options) || isIP(hostname);
} 




