### PR TITLE
feat(normalizeEmail): optional yandex domain conversion

### DIFF
--- a/src/lib/normalizeEmail.js
+++ b/src/lib/normalizeEmail.js
@@ -32,6 +32,8 @@ const default_normalize_email_options = {
   // The following conversions are specific to Yandex
   // Lowercases the local part of the Yandex address (known to be case-insensitive)
   yandex_lowercase: true,
+  // all yandex domains are equal, this explicitly sets the domain to 'yandex.ru'
+  yandex_convert_yandexru: true,
 
   // The following conversions are specific to iCloud
   // Lowercases the local part of the iCloud address (known to be case-insensitive)
@@ -232,7 +234,7 @@ export default function normalizeEmail(email, options) {
     if (options.all_lowercase || options.yandex_lowercase) {
       parts[0] = parts[0].toLowerCase();
     }
-    parts[1] = 'yandex.ru'; // all yandex domains are equal, 1st preferred
+    parts[1] = options.yandex_convert_yandexru ? 'yandex.ru' : parts[1];
   } else if (options.all_lowercase) {
     // Any other address
     parts[0] = parts[0].toLowerCase();

--- a/test/sanitizers.test.js
+++ b/test/sanitizers.test.js
@@ -481,5 +481,34 @@ describe('Sanitizers', () => {
         'my.self@foo.com': 'my.self@foo.com',
       },
     });
+
+    // Testing yandex_convert_yandexru
+    test({
+      sanitizer: 'normalizeEmail',
+      args: [{
+        yandex_convert_yandexru: false,
+      }],
+      expect: {
+        'test@yandex.kz': 'test@yandex.kz',
+        'test@yandex.ru': 'test@yandex.ru',
+        'test@yandex.ua': 'test@yandex.ua',
+        'test@yandex.com': 'test@yandex.com',
+        'test@yandex.by': 'test@yandex.by',
+      },
+    });
+
+    test({
+      sanitizer: 'normalizeEmail',
+      args: [{
+        yandex_convert_yandexru: true,
+      }],
+      expect: {
+        'test@yandex.kz': 'test@yandex.ru',
+        'test@yandex.ru': 'test@yandex.ru',
+        'test@yandex.ua': 'test@yandex.ru',
+        'test@yandex.com': 'test@yandex.ru',
+        'test@yandex.by': 'test@yandex.ru',
+      },
+    });
   });
 });


### PR DESCRIPTION
Added an option to ignore yandex domain conversion. Currently @yandex.ua is being converted to @yandex.ru. Added support to make this behaviour optional.

Refer Issue #2440 

## Checklist

- [x] PR contains only changes related; no stray files, etc.
- [ ] README updated (where applicable)
- [x] Tests written (where applicable)
- [ ] References provided in PR (where applicable)
