### PR TITLE
test(testFunctions): display stringified arguments in error message

### DIFF
--- a/test/testFunctions.js
+++ b/test/testFunctions.js
@@ -2,6 +2,10 @@ import assert from 'assert';
 import { format } from 'util';
 import validator from '../src/index';
 
+function stringifyArgs(argsArr) {
+  return argsArr.map(arg => JSON.stringify(arg)).join(', ');
+}
+
 export default function test(options) {
   const args = options.args || [];
 
@@ -16,7 +20,7 @@ export default function test(options) {
       } catch (err) {
         const warning = format(
           'validator.%s(%s) passed but should error',
-          options.validator, args.join(', ')
+          options.validator, stringifyArgs(args)
         );
 
         throw new Error(warning);
@@ -31,7 +35,7 @@ export default function test(options) {
       if (validator[options.validator](...args) !== true) {
         const warning = format(
           'validator.%s(%s) failed but should have passed',
-          options.validator, args.join(', ')
+          options.validator, stringifyArgs(args)
         );
 
         throw new Error(warning);
@@ -46,7 +50,7 @@ export default function test(options) {
       if (validator[options.validator](...args) !== false) {
         const warning = format(
           'validator.%s(%s) passed but should have failed',
-          options.validator, args.join(', ')
+          options.validator, stringifyArgs(args)
         );
 
         throw new Error(warning);


### PR DESCRIPTION
Hello,

the error message that the testFunctions currently throws, when a test case fails is currently not correctly displaying options objects, even though the intention clearly is there.

This pull request properly implements this now, by stringifying the arguments, making sure they can get correctly printed as string.

Before
`Error: validator.isDate("2024/05/01", [Object object]) passed but should have failed`
After:
`Error: validator.isDate("2024/05/01", {"delimiters":["/"," "],"format":"YYYY/MM/DD","strictMode":false}) passed but should have failed`

This is achieved by a tiny helper function that maps through the args and JSON.stringifys them.

All of these are available since node v0.10, so we still are compatible with that (ancient :)) version:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map#browser_compatibility
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify

I would've like to replace the "format" function with template literals as well, but these were not available in node 0.10.0 (which is the minimum engine mentioned in the package.json) yet, but only came with node 4.


## Checklist

- [x] PR contains only changes related; no stray files, etc.
- [x] README updated (where applicable)
- [x] Tests written (where applicable)
- [x] References provided in PR (where applicable)
