### PR TITLE
fix : issue #2430 isNumeric doesn't support scientific notation

### DIFF
--- a/src/lib/isNumeric.js
+++ b/src/lib/isNumeric.js
@@ -8,5 +8,5 @@ export default function isNumeric(str, options) {
   if (options && options.no_symbols) {
     return numericNoSymbols.test(str);
   }
-  return (new RegExp(`^[+-]?([0-9]*[${(options || {}).locale ? decimal[options.locale] : '.'}])?[0-9]+$`)).test(str);
+  return (new RegExp(`^[+-]?([0-9]*[${(options || {}).locale ? decimal[options.locale] : '.'}])?[0-9]+([eE][+-]?[0-9]+)?$`)).test(str);
 }

--- a/test/validators.test.js
+++ b/test/validators.test.js
@@ -2825,6 +2825,27 @@ describe('Validators', () => {
     });
   });
 
+  it('should validate numeric strings with scientific notation', () => {
+    test({
+      validator: 'isNumeric',
+      valid: [
+        '2e+21',
+        '-3.5E-8',
+        '3.14e2',
+        '1.23e+10',
+        '-0.001e-5',
+      ],
+      invalid: [
+        'e10',
+        '2e+',
+        '3.14e',
+        'e',
+        '3.14e-',
+        '2E+G',
+      ],
+    });
+  });
+
   it('should validate numeric strings without symbols', () => {
     test({
       validator: 'isNumeric',


### PR DESCRIPTION
#2430 fix(isNumeric): Add support for scientific notation

This PR addresses the issue described in issue #2430, where the isNumeric function did not support scientific notation. The regular expression used in isNumeric was updated to correctly validate numeric strings in scientific notation formats, such as '2e+21' and '-3.5E-8'. This change ensures that isNumeric can handle a wider range of numeric formats and provides more accurate validation.

References

Issue: [validator.js issue isNumeric doesn't support scientific notation #2430](https://github.com/validatorjs/validator.js/issues/2430)


## Checklist

- [x] PR contains only changes related; no stray files, etc.
- [ ] README updated (where applicable)
- [x] Tests written (where applicable)
- [ ] References provided in PR (where applicable)
