### PR TITLE
(Bug Fix) isDate function: Add validation for delimiter and length ch…

### DIFF
--- a/src/lib/isDate.js
+++ b/src/lib/isDate.js
@@ -1,4 +1,4 @@
-import merge from "./util/merge";
+import merge from './util/merge';
 
 const default_date_options = {
   format: 'YYYY/MM/DD',
@@ -7,14 +7,12 @@ const default_date_options = {
 };
 
 function isValidFormat(format) {
-  return /(^(y{4}|y{2})[.\/-](m{1,2})[.\/-](d{1,2})$)|(^(m{1,2})[.\/-](d{1,2})[.\/-]((y{4}|y{2})$))|(^(d{1,2})[.\/-](m{1,2})[.\/-]((y{4}|y{2})$))/gi.test(
-    format
-  );
+  return /(^(y{4}|y{2})[.\/-](m{1,2})[.\/-](d{1,2})$)|(^(m{1,2})[.\/-](d{1,2})[.\/-]((y{4}|y{2})$))|(^(d{1,2})[.\/-](m{1,2})[.\/-]((y{4}|y{2})$))/gi.test(format);
 }
 
 function zip(date, format) {
-  const zippedArr = [],
-    len = Math.max(date.length, format.length);
+  const zippedArr = [];
+  const len = Math.max(date.length, format.length);
 
   for (let i = 0; i < len; i++) {
     zippedArr.push([date[i], format[i]]);
@@ -30,21 +28,18 @@ export default function isDate(input, options) {
   } else {
     options = merge(options, default_date_options);
   }
+
   if (typeof input === 'string' && isValidFormat(options.format)) {
     // Ensure the input contains at least one valid delimiter
-    const hasValidDelimiter = options.delimiters.some((delimiter) =>
-      input.includes(delimiter)
-    );
+    const hasValidDelimiter = options.delimiters.some(delimiter => input.includes(delimiter));
     if (!hasValidDelimiter) {
       return false;
     }
 
-    const formatDelimiter = options.delimiters.find(
-      (delimiter) => options.format.indexOf(delimiter) !== -1
-    );
+    const formatDelimiter = options.delimiters.find(delimiter => options.format.indexOf(delimiter) !== -1);
     const dateDelimiter = options.strictMode
       ? formatDelimiter
-      : options.delimiters.find((delimiter) => input.indexOf(delimiter) !== -1);
+      : options.delimiters.find(delimiter => input.indexOf(delimiter) !== -1);
 
     // Split input and format by the delimiters
     const inputParts = input.split(dateDelimiter);
@@ -107,9 +102,7 @@ export default function isDate(input, options) {
   }
 
   if (!options.strictMode) {
-    return (
-       Object.prototype.toString.call(input) === '[object Date]' && isFinite(input)
-    );
+    return Object.prototype.toString.call(input) === '[object Date]' && isFinite(input);
   }
 
   return false;

--- a/src/lib/isDate.js
+++ b/src/lib/isDate.js
@@ -1,8 +1,8 @@
 import merge from "./util/merge";
 
 const default_date_options = {
-  format: "YYYY/MM/DD",
-  delimiters: ["/", "-"],
+  format: 'YYYY/MM/DD',
+  delimiters: ['/', '-'],
   strictMode: false,
 };
 
@@ -24,13 +24,13 @@ function zip(date, format) {
 }
 
 export default function isDate(input, options) {
-  if (typeof options === "string") {
+  if (typeof options === 'string') {
     // Allow backward compatibility for old format isDate(input [, format])
     options = merge({ format: options }, default_date_options);
   } else {
     options = merge(options, default_date_options);
   }
-  if (typeof input === "string" && isValidFormat(options.format)) {
+  if (typeof input === 'string' && isValidFormat(options.format)) {
     // Ensure the input contains at least one valid delimiter
     const hasValidDelimiter = options.delimiters.some((delimiter) =>
       input.includes(delimiter)
@@ -69,7 +69,7 @@ export default function isDate(input, options) {
     let fullYear = dateObj.y;
 
     // Check if the year starts with a hyphen
-    if (fullYear.startsWith("-")) {
+    if (fullYear.startsWith('-')) {
       return false; // Hyphen before year is not allowed
     }
 
@@ -108,8 +108,7 @@ export default function isDate(input, options) {
 
   if (!options.strictMode) {
     return (
-      Object.prototype.toString.call(input) === "[object Date]" &&
-      isFinite(input)
+       Object.prototype.toString.call(input) === '[object Date]' && isFinite(input)
     );
   }
 


### PR DESCRIPTION
Issue  #2452 

fix(isDate): Add validation for delimiter and length checks to prevent undefined errors

Enhanced the `isDate` function by verifying valid delimiters and ensuring that input and format parts are properly validated before performing length comparisons. This prevents undefined errors when an invalid string (e.g., "abcd") is passed. The input string is now properly validated against the format.

No external references were used, but this fix was based on the structure of how the `isDate` function processes date formats and delimiters.

## Checklist
- [x] PR contains only changes related; no stray files, etc.
- [ ] README updated (where applicable)
- [ ] Tests written (where applicable)
- [ ] References provided in PR (where applicable)
