### PR TITLE
Export analyzePassword Function

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ Sanitizer                              | Description
 **trim(input [, chars])**              | trim characters (whitespace by default) from both sides of the input.
 **unescape(input)**                    | replace HTML encoded entities with `<`, `>`, `&`, `'`, `"`, `` ` ``, `\` and `/`.
 **whitelist(input, chars)**            | remove characters that do not appear in the whitelist. The characters are used in a RegExp and so you will need to escape some chars, e.g. `whitelist(input, '\\[\\]')`.
+**analyzePassword(str)**                | Analyzes and returns details about the given string's composition as a password. Returns an object containing the password's length, count of unique characters, and the number of uppercase letters, lowercase letters, numbers, and symbols.
 
 ### XSS Sanitization
 

--- a/src/index.js
+++ b/src/index.js
@@ -125,7 +125,7 @@ import normalizeEmail from './lib/normalizeEmail';
 
 import isSlug from './lib/isSlug';
 import isLicensePlate from './lib/isLicensePlate';
-import isStrongPassword from './lib/isStrongPassword';
+import {isStrongPassword, analyzePassword} from './lib/isStrongPassword';
 
 import isVAT from './lib/isVAT';
 
@@ -237,6 +237,7 @@ const validator = {
   toString,
   isSlug,
   isStrongPassword,
+  analyzePassword,
   isTaxID,
   isDate,
   isTime,

--- a/src/lib/isStrongPassword.js
+++ b/src/lib/isStrongPassword.js
@@ -38,7 +38,7 @@ function countChars(str) {
 }
 
 /* Return information about a password */
-function analyzePassword(password) {
+export default function analyzePassword(password) {
   let charMap = countChars(password);
   let analysis = {
     length: password.length,


### PR DESCRIPTION
<!--
Add a descriptive title textbox above, e.g.
feat(validatorName): brief title of what has been done
-->

<!--- briefly describe what you have done in this PR --->
Initially pointed out in #1966 to adapt `isStrongPassword` to return count of all type of characters in the password.
The responsibility of `isStrongPassword` should only be to check if the password is strong or not. So instead of modifying `isStrongPassword`,  `analyzePassword` is exported which can be used to know the count of all type of characters in the password.

<!--- provide some (credible) references showing the structure of the data to be validated, if applicable --->
The issue is also attempted to solve here #2033 

## Checklist

- [x] PR contains only changes related; no stray files, etc.
- [x] README updated (where applicable)
- [ ] Tests written (where applicable)
- [x] References provided in PR (where applicable)
