### PR TITLE
fix(email-validation): reject quoted emails with blacklisted characters

### DIFF
--- a/src/lib/isEmail.js
+++ b/src/lib/isEmail.js
@@ -163,7 +163,14 @@ export default function isEmail(str, options) {
   }
 
   if (options.blacklisted_chars) {
+    // Check for blacklisted characters in the raw user part
     if (user.search(new RegExp(`[${options.blacklisted_chars}]+`, 'g')) !== -1) return false;
+
+    // If the user part is quoted, remove the quotes and recheck
+    if (user[0] === '"' && user[user.length - 1] === '"') {
+      const strippedUser = user.slice(1, user.length - 1);
+      if (strippedUser.search(new RegExp(`[${options.blacklisted_chars}]+`, 'g')) !== -1) return false;
+    }
   }
 
   if (user[0] === '"' && user[user.length - 1] === '"') {

--- a/test/validators.test.js
+++ b/test/validators.test.js
@@ -281,6 +281,23 @@ describe('Validators', () => {
     });
   });
 
+  it('should not validate email addresses with quotes in the local part', () => {
+    test({
+      validator: 'isEmail',
+      args: [{ blacklisted_chars: '"' }],
+      valid: [
+        'foo@bar.com',
+        'test@example.com',
+      ],
+      invalid: [
+        '"foobar"@example.com',
+        '"foo"bar@example.com',
+        'foo"bar"@example.com',
+        '"  foo  m端ller "@example.com',
+        '"foo\\@bar"@example.com',
+      ],
+    });
+  });
 
   it('should validate really long emails if ignore_max_length is set', () => {
     test({


### PR DESCRIPTION
Fix (email-validation): reject quoted emails with blacklisted characters

Pointed out in issue [2392](https://github.com/validatorjs/validator.js/issues/2392) -  isEmail does not reject emails when blacklisted_chars includes quote.
To resolve this issue, the email validation function should be updated to properly enforce the blacklisting of quotes in the user part of the email. This can be achieved by:
 - Modifying the validation logic to check for blacklisted characters specifically in the user part of the email before further 
   processing.
 - Implementing unit tests to cover various scenarios, including those provided above, to ensure that quotes are effectively 
   excluded from valid email addresses.

## Checklist

- [x] PR contains only changes related; no stray files, etc.
- [ ] README updated (where applicable)
- [ ] Tests written (where applicable)
- [x] References provided in PR (where applicable)
