### PR TITLE
fix #2448 : isUrl fails for URLs that do not use domain suffixes

### DIFF
--- a/src/lib/isURL.js
+++ b/src/lib/isURL.js
@@ -85,7 +85,7 @@ export default function isURL(url, options) {
   split = url.split('://');
   if (split.length > 1) {
     protocol = split.shift().toLowerCase();
-    if (options.require_valid_protocol && options.protocols.indexOf(protocol) === -1) {
+    if (options.require_valid_protocol && !protocol) {
       return false;
     }
   } else if (options.require_protocol) {


### PR DESCRIPTION
<!--
Add a descriptive title textbox above, e.g.
-->
feat(isURL): fix for isUrl fails for URLs that do not use domain suffixes
<!--- briefly describe what you have done in this PR --->
```if (options.require_valid_protocol && options.protocols.indexOf(protocol) === -1)``` changed to ```if (options.require_valid_protocol && !protocol)```
<!--- provide some (credible) references showing the structure of the data to be validated, if applicable --->

## Checklist

- [X] PR contains only changes related; no stray files, etc.
- [ ] README updated (where applicable)
- [ ] Tests written (where applicable)
- [ ] References provided in PR (where applicable)
