### PR TITLE
fixes #2430 - scientific notation support

### DIFF
--- a/src/lib/isNumeric.js
+++ b/src/lib/isNumeric.js
@@ -1,5 +1,5 @@
-import assertString from './util/assertString';
-import { decimal } from './alpha';
+import assertString from "./util/assertString";
+import { decimal } from "./alpha";
 
 const numericNoSymbols = /^[0-9]+$/;
 
@@ -8,5 +8,10 @@ export default function isNumeric(str, options) {
   if (options && options.no_symbols) {
     return numericNoSymbols.test(str);
   }
-  return (new RegExp(`^[+-]?([0-9]*[${(options || {}).locale ? decimal[options.locale] : '.'}])?[0-9]+$`)).test(str);
+
+  const decimalSymbol = (options || {}).locale ? decimal[options.locale] : ".";
+
+  return new RegExp(
+    `^[+-]?(?:\\d+|\\d*${decimalSymbol}\\d+)(?:[eE][+-]?\\d+)?$`
+  ).test(str);
 }


### PR DESCRIPTION
# Fixes isNumeric Validator

I have updated the isNumeric function in "src/lib/isNumeric.js". I have included a more robust regex to handle large numbers solving the error associated with the scientific notation.

File changed
<img width="507" alt="file" src="https://github.com/user-attachments/assets/539ed4c1-3994-40ac-bfd7-d86c03843c23">

## Checklist

- [x] PR contains only changes related; no stray files, etc. The only file updated is "src/lib/isNumeric.js"
- [ ] README updated (where applicable)
- [ ] Tests written (where applicable)
- [x] References provided in PR (where applicable)
