### PR TITLE
Fix: isURL incorrectly accepts email-like strings (#1674)

### DIFF
--- a/src/lib/isURL.js
+++ b/src/lib/isURL.js
@@ -61,6 +61,19 @@ export default function isURL(url, options) {
   if (url.indexOf('mailto:') === 0) {
     return false;
   }
+
+  const isURLHasProtocol = /^([a-z0-9.+-]+:)?\/\//i.test(url);
+
+  if (!isURLHasProtocol) {
+    const emailLikeRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+    if (!options || options.disallow_auth !== false) {
+      if (emailLikeRegex.test(url)) {
+        return false;
+      }
+    }
+  }
+
   options = merge(options, default_url_options);
 
   if (options.validate_length && url.length > options.max_allowed_length) {

--- a/test/validators.test.js
+++ b/test/validators.test.js
@@ -469,6 +469,21 @@ describe('Validators', () => {
       ],
     });
   });
+  
+  it('should not validate email-like strings as URLs', () => {
+    test({
+      validator: 'isURL',
+      valid: [],
+      invalid: [
+        'test@email.com',
+        'first.last@domain.co.uk',
+        'user+category@gmail.com',
+        'user_name@example.com',
+        'user-name@domain.org',
+        'john..doe@example.com',
+      ],
+    });
+  });
 
   it('should validate URLs with custom protocols', () => {
     test({


### PR DESCRIPTION
## Description

This pull request fixes the issue where `isURL` incorrectly accepted email-like strings such as `test@email.com` as valid URLs.

### Changes:
- Added a check to detect email-like strings only when no protocol is present.
- Respected the `disallow_auth` option to avoid breaking URLs containing authentication info like `user:pass@host`.

Closes #1674.

---

✅ All tests passed after the fix.
✅ No breaking changes for authentication URLs.
✅ Code style consistent with the rest of the project.
