### PR TITLE
test: Fix typo in validators.test.js

### DIFF
--- a/test/validators.test.js
+++ b/test/validators.test.js
@@ -8123,7 +8123,7 @@ describe('Validators', () => {
         ],
       },
       {
-        local: 'en-LS',
+        locale: 'en-LS',
         valid: [
           '+26622123456',
           '+26628123456',


### PR DESCRIPTION
Use `locale:` instead of `local:` for isPhoneNumber test.

## Checklist

- [x] PR contains only changes related; no stray files, etc.
- [x] README updated (where applicable)
- [x] Tests written (where applicable)
- [x] References provided in PR (where applicable)
