### PR TITLE
maintenance: 2508 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# 13.15.19
+
+### Fixes, New Locales and Enhancements
+
+- [#2556](https://github.com/validatorjs/validator.js/pull/2556) `isMobilePhone`: add `ar-QA` locale @WardKhaddour
+- [#2576](https://github.com/validatorjs/validator.js/pull/2576) `isAlpha`/`isAlphanuneric`: add Indic locales (`ta-IN`, `te-IN`, `kn-IN`, `ml-IN`, `gu-IN`, `pa-IN`, `or-IN`) @avadootharajesh
+- [#2574](https://github.com/validatorjs/validator.js/pull/2574) `isBase64`: improve padding regex @KrayzeeKev
+- [#2584](https://github.com/validatorjs/validator.js/pull/2584) `isVAT`: improve `FR` locale @iamAmer
+- **Doc fixes and others:**
+  - [#2563](https://github.com/validatorjs/validator.js/pull/2563) @stoneLeaf
+
 # 13.15.15
 
 ### Fixes, New Locales and Enhancements

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "validator",
   "description": "String validation and sanitization",
-  "version": "13.15.15",
+  "version": "13.15.19",
   "sideEffects": false,
   "homepage": "https://github.com/validatorjs/validator.js",
   "files": [

--- a/src/index.js
+++ b/src/index.js
@@ -130,7 +130,7 @@ import isStrongPassword from './lib/isStrongPassword';
 
 import isVAT from './lib/isVAT';
 
-const version = '13.15.15';
+const version = '13.15.19';
 
 const validator = {
   version,


### PR DESCRIPTION
# 13.15.19

### Fixes, New Locales and Enhancements

- [#2556](https://github.com/validatorjs/validator.js/pull/2556) `isMobilePhone`: add `ar-QA` locale @WardKhaddour
- [#2576](https://github.com/validatorjs/validator.js/pull/2576) `isAlpha`/`isAlphanuneric`: add Indic locales (`ta-IN`, `te-IN`, `kn-IN`, `ml-IN`, `gu-IN`, `pa-IN`, `or-IN`) @avadootharajesh
- [#2574](https://github.com/validatorjs/validator.js/pull/2574) `isBase64`: improve padding regex @KrayzeeKev
- [#2584](https://github.com/validatorjs/validator.js/pull/2584) `isVAT`: improve `FR` locale @iamAmer
- **Doc fixes and others:**
  - [#2563](https://github.com/validatorjs/validator.js/pull/2563) @stoneLeaf
