### PR TITLE
improved isJWT.js to decode base64 strings and verify them

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,5 @@ yarn.lock
 /index.js
 validator.js
 validator.min.js
+.idea
 

--- a/src/lib/isJWT.js
+++ b/src/lib/isJWT.js
@@ -1,15 +1,37 @@
-import assertString from './util/assertString';
-import isBase64 from './isBase64';
+import assertString from './util/assertString'
 
-export default function isJWT(str) {
-  assertString(str);
+function decodeBase64Url (str) {
+  str = str.replace(/-/g, '+').replace(/_/g, '/')
+  const pad = str.length % 4
+  if (pad) str += '='.repeat(4 - pad)
 
-  const dotSplit = str.split('.');
-  const len = dotSplit.length;
+  if (typeof Buffer !== 'undefined') {
+    // Node.js
+    return Buffer.from(str, 'base64').toString('utf8')
+  } else if (typeof atob !== 'undefined') {
+    // Browser
+    return atob(str)
+  } else {
+    throw new Error('No base64 decoder available')
+  }
+}
 
-  if (len !== 3) {
-    return false;
+export default function isJWT (str) {
+  assertString(str)
+
+  const parts = str.split('.')
+  if (parts.length !== 3) return false
+  try {
+    const header = JSON.parse(decodeBase64Url(parts[0]))
+    const payload = JSON.parse(decodeBase64Url(parts[1]))
+
+    if (typeof header !== 'object' || header === null) return false
+    if (typeof payload !== 'object' || payload === null) return false
+    if (typeof header.alg !== 'string') return false
+
+    return true
+  } catch (e) {
+    return false
   }
 
-  return dotSplit.reduce((acc, currElem) => acc && isBase64(currElem, { urlSafe: true }), true);
 }


### PR DESCRIPTION

Improvement(isJWT): Improved isJWT to decode the JWT base64 strings and verify if they are valid objects after decoding and parsing them (issue #2511)

<!--- briefly describe what you have done in this PR --->
Fixed issue #2251 by verifying that the JWT string are actual JSON objects after decoding them(base64 to utf8) and parsing them into JSON, and then verifying the given JSON.


<!--- provide some (credible) references showing the structure of the data to be validated, if applicable --->

## Checklist

- [ ] PR contains only changes related; no stray files, etc.
- [ ] README updated (where applicable)
- [ ] Tests written (where applicable)
- [ ] References provided in PR (where applicable)
