### PR TITLE
improved isJWT to decode Base64 strings and verify their types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,5 @@ yarn.lock
 /index.js
 validator.js
 validator.min.js
+.idea
 


### PR DESCRIPTION
Improvement(isJWT): improved isJWT to decode the given JWT string, parse them and verify that it is valid JSON (#2511)

<!--- briefly describe what you have done in this PR --->

Fixed the bug mentioned in #2511, by splitting the JWT string,  decoding the base64 strings from it to utf8, parsing them and checking if they are valid JSON.

## Checklist

- [ ] PR contains only changes related; no stray files, etc.
- [ ] README updated (where applicable)
- [ ] Tests written (where applicable)
- [ ] References provided in PR (where applicable)
