### PR TITLE
ci: remove Node 6 testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [22, 20, 18, 16, 14, 12, 10, 8, 6]
+        node-version: [22, 20, 18, 16, 14, 12, 10, 8]
     name: Run tests on Node.js ${{ matrix.node-version }}
     steps:
     - name: Setup Node.js ${{ matrix.node-version }}


### PR DESCRIPTION
<!--
Add a descriptive title textbox above, e.g.
feat(validatorName): brief title of what has been done
-->

<!--- briefly describe what you have done in this PR --->

This removes Node 6 from the test because of dependency issues. `@babel/preset-env` uses `browerslist` which uses `baseline-browser-mapping`. The maintainer of `baseline-browser-mapping` has indicated in https://github.com/web-platform-dx/baseline-browser-mapping/issues/103#issuecomment-3405835064 that Node 8 is the minimal supported version and targeting Node 6 is a bit of work. `browerslist` does support Node 6, but does not test on it because `uvu` (the test runner) does not support Node 6. 

Because of the history of this project, I would be hestitant in changing the build configuration without shipping a new major release (and dropping support for Node versions that are end of life). And since we support Node >=0.10 without testing until Node 6, I think it's fine if we remove testing for Node 6 as well.

To be clear; this does not change anything in our build or what Node versions we support, just in the way that we test changes.

<!--- provide some (credible) references showing the structure of the data to be validated, if applicable --->

## Checklist

- [X] PR contains only changes related; no stray files, etc.
- [ ] README updated (where applicable)
- [ ] Tests written (where applicable)
- [X] References provided in PR (where applicable)
