### PR TITLE
fix: URL validation for hostnames with ports (no protocol)

### DIFF
--- a/src/lib/isURL.js
+++ b/src/lib/isURL.js
@@ -142,11 +142,24 @@ export default function isURL(url, options) {
           }
         }
       } else {
-        // No @ symbol, this is definitely a protocol
-        url = cleanUpProtocol(potential_protocol);
+        // No @ symbol found. Check if this could be a port number instead of a protocol.
+        // If what's after the colon is numeric (or starts with a digit and contains only
+        // valid port characters until a path separator), it's likely hostname:port, not a protocol.
+        const looks_like_port = /^[0-9]/.test(after_colon);
 
-        if (url === false) {
-          return false;
+        if (looks_like_port) {
+          // This looks like hostname:port, not a protocol
+          if (options.require_protocol) {
+            return false;
+          }
+          // Don't consume anything; let it be parsed as hostname:port
+        } else {
+          // This is definitely a protocol
+          url = cleanUpProtocol(potential_protocol);
+
+          if (url === false) {
+            return false;
+          }
         }
       }
     } else {

--- a/test/validators.test.js
+++ b/test/validators.test.js
@@ -488,6 +488,62 @@ describe('Validators', () => {
     });
   });
 
+  it('should validate URLs without protocol', () => {
+    test({
+      validator: 'isURL',
+      args: [{
+        require_tld: false,
+        require_valid_protocol: false,
+      }],
+      valid: [
+        'localhost',
+        'localhost:3000',
+        'service-name:8080',
+        'https://localhost',
+        'http://localhost:3000',
+        'http://service-name:8080',
+        'user:password@localhost',
+        'user:pass@service-name:8080',
+      ],
+      invalid: [],
+    });
+
+    // Test with require_protocol: true - should reject hostnames with ports but no protocol
+    test({
+      validator: 'isURL',
+      args: [{
+        require_tld: false,
+        require_protocol: true,
+        require_valid_protocol: false,
+      }],
+      valid: [
+        'http://localhost:3000',
+        'https://service-name:8080',
+        'custom://localhost',
+      ],
+      invalid: [
+        'localhost:3000',
+        'service-name:8080',
+        'user:password@localhost',
+      ],
+    });
+
+    // Test non-numeric patterns after colon (should be treated as protocols)
+    test({
+      validator: 'isURL',
+      args: [{
+        require_tld: false,
+        require_valid_protocol: false,
+        protocols: ['custom', 'myscheme'],
+      }],
+      valid: [
+        'custom:something',
+        'myscheme:data',
+      ],
+      invalid: [],
+    });
+  });
+
   it('should validate URLs with custom protocols', () => {
     test({
       validator: 'isURL',


### PR DESCRIPTION
Fixes a bug in `isURL` where URLs like `localhost:3000` and `service-name:8080` were incorrectly rejected when`require_protocol` was set to `false`. The validator was misinterpreting the colon in `hostname:port` patterns as a protocol delimiter.

I added tests to cover this case and a couple other option variations.

Regression #2608
Closes #2620 

## Checklist

- [x] PR contains only changes related; no stray files, etc.
- [x] README updated (where applicable)
- [x] Tests written (where applicable)
- [x] References provided in PR (where applicable)
