### PR TITLE
maintenance: 2511 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# 13.15.22
+
+### Fixes, New Locales and Enhancements
+
+- [#2622](https://github.com/validatorjs/validator.js/pull/2622) `isURL`: fix regression with hostnames with ports @mbtools
+- [#2616](https://github.com/validatorjs/validator.js/pull/2616) `isLength`: improve handling Unicode variation selectors @koral--
+- **Doc fixes and others:**
+  - [#2621](https://github.com/validatorjs/validator.js/pull/2621) @mbtools
+
 # 13.15.20
 
 ### Fixes, New Locales and Enhancements

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "validator",
   "description": "String validation and sanitization",
-  "version": "13.15.20",
+  "version": "13.15.22",
   "sideEffects": false,
   "homepage": "https://github.com/validatorjs/validator.js",
   "files": [

--- a/src/index.js
+++ b/src/index.js
@@ -130,7 +130,7 @@ import isStrongPassword from './lib/isStrongPassword';
 
 import isVAT from './lib/isVAT';
 
-const version = '13.15.20';
+const version = '13.15.22';
 
 const validator = {
   version,


### PR DESCRIPTION
# 13.15.22

### Fixes, New Locales and Enhancements

- [#2622](https://github.com/validatorjs/validator.js/pull/2622) `isURL`: fix regression with hostnames with ports @mbtools
- [#2616](https://github.com/validatorjs/validator.js/pull/2616) `isLength`: improve handling Unicode variation selectors @koral--
- **Doc fixes and others:**
  - [#2621](https://github.com/validatorjs/validator.js/pull/2621) @mbtools
