### PR TITLE
docs: correct ESM import paths for Node.js compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,12 @@ import validator from 'validator';
 Or, import only a subset of the library:
 
 ```javascript
+// For Bundlers (Webpack, Vite, etc.)
 import isEmail from 'validator/lib/isEmail';
+
+// For Native Node.js ESM
+// Note: Use /lib instead of /es/lib, and include the .js extension
+import isEmail from 'validator/lib/isEmail.js';
 ```
 
 #### Tree-shakeable ES imports


### PR DESCRIPTION
Updated the documentation to clarify that native Node.js ESM users should use the `/lib` path with a `.js` extension. The `/es` directory contains source code without file extensions in its internal imports, which causes `ERR_MODULE_NOT_FOUND` in native Node.js environments (as they don't perform automatic extension resolution).