### PR TITLE
fix(isPassportNumber): improve `MX` locale

### DIFF
--- a/src/lib/isPassportNumber.js
+++ b/src/lib/isPassportNumber.js
@@ -50,7 +50,7 @@ const passportRegexByCountryCode = {
   MT: /^\d{7}$/, // MALTA
   MZ: /^([A-Z]{2}\d{7})|(\d{2}[A-Z]{2}\d{5})$/, // MOZAMBIQUE
   MY: /^[AHK]\d{8}$/, // MALAYSIA
-  MX: /^\d{10,11}$/, // MEXICO
+  MX: /^[A-Z]\d{8}$/, // MEXICO
   NL: /^[A-Z]{2}[A-Z0-9]{6}\d$/, // NETHERLANDS
   NZ: /^([Ll]([Aa]|[Dd]|[Ff]|[Hh])|[Ee]([Aa]|[Pp])|[Nn])\d{6}$/, // NEW ZEALAND
   PH: /^([A-Z](\d{6}|\d{7}[A-Z]))|([A-Z]{2}(\d{6}|\d{7}))$/, // PHILIPPINES

--- a/test/validators.test.js
+++ b/test/validators.test.js
@@ -3805,11 +3805,13 @@ describe('Validators', () => {
       validator: 'isPassportNumber',
       args: ['MX'],
       valid: [
-        '43986369222',
-        '01234567890',
+        'G98639222',
+        'N23457890',
       ],
       invalid: [
         'ABC34567890',
+        '43986369222',
+        'N234578909',
         '34567890',
       ],
     });


### PR DESCRIPTION
<!--
Add a descriptive title textbox above, e.g.
feat(validatorName): brief title of what has been done
-->
issue: #2641 
<!--- briefly describe what you have done in this PR --->
Mexican passport number format changed with the introduction of the biometric electronic passport (ePassport) in October 2021
Passport numbers with 10 or 11 characters are generally considered invalid after their expiry. Until expiry, only 9 alphanumeric characters are considered valid, after excluding the first two characters, which usually represent the year.
in short,
Older passports are still valid and follow a format of one letter followed by eight digits.
Modern ePassports use a 9-character alphanumeric format, usually starting with “G” or “N” series.
Even though, it's alphanumeric I still couldn't find examples where other digits are letters except first.

so my solution is to go for starting with a letter and 8 numbers. It supports both old and new format.
I have changed regex for mexico in isPassportNumber and added some test cases.

<!--- provide some (credible) references showing the structure of the data to be validated, if applicable --->

source for Mexican Passport change: https://en.wikipedia.org/wiki/Mexican_passport
source for correct validations:  https://www.brandeis.edu/isso/travel/form-i94/tips.html
source for examples: https://trustdochub.com/en/verify-mexican-passport/
https://www.microfocus.com/documentation/idol/IDOL_24_3/EductionGrammars_24.3_Documentation/PII/Content/PII/PII_Examples_Passport.htm  
## Checklist

- [x] PR contains only changes related; no stray files, etc.
- [ ] README updated (where applicable)
- [x] Tests written (where applicable)
- [x] References provided in PR (where applicable)
