### PR TITLE
feat: add support for alphanumeric CNPJ format (effective July 2026)

### DIFF
--- a/test/validators.test.js
+++ b/test/validators.test.js
@@ -13994,10 +13994,16 @@ describe('Validators', () => {
       validator: 'isTaxID',
       args: ['pt-BR'],
       valid: [
+        // CPF (persons)
         '35161990910',
         '74407265027',
+        // CNPJ numeric (legacy format)
         '05423994000172',
-        '11867044000130'],
+        '11867044000130',
+        // CNPJ alphanumeric (new format starting July 2026)
+        '12ABC34501DE35', // Example from official SERPRO documentation
+        '12abc34501de35', // Lowercase should also work
+      ],
       invalid: [
         'ABCDEFGH',
         '170.691.440-72',
@@ -14011,6 +14017,12 @@ describe('Validators', () => {
         '111111111111112',
         '61938188550993',
         '82168365502729',
+        // Invalid alphanumeric CNPJs
+        '12ABC34501DE00', // Wrong check digits
+        '12ABC34501DE99', // Wrong check digits
+        'AAAAAAAAAAAAAA', // All same characters
+        '00000000000000', // All zeros
+        '12.ABC.345/01DE-35', // Formatted (not accepted)
       ],
     });
     test({


### PR DESCRIPTION
## Description

This PR implements support for the upcoming alphanumeric CNPJ format (effective July 2026) for Brazilian tax IDs, as described in issue #2639.

Starting July 2026, Brazil's Receita Federal will support alphanumeric CNPJs with the same structure as numeric CNPJs but allowing letters A-Z in addition to digits 0-9.

## Changes

- Update `ptBrCheck` function in `src/lib/isTaxID.js` to validate both numeric and alphanumeric CNPJs
- Add character-to-value conversion (A-Z → 17-42) following the formula: ASCII code - 48
- Maintain backward compatibility with numeric-only CNPJs
- Add comprehensive tests for both formats including:
  - Existing numeric CNPJs (backward compatibility)
  - New alphanumeric CNPJs (including official example `12.ABC.345/01DE-35`)
  - Invalid CNPJs in both formats
  - Formatted and unformatted inputs

## References

- Official SERPRO documentation: [Cálculo dos dígitos verificadores de CNPJ alfanumérico](https://www.serpro.gov.br) (PDF provided by the Brazilian government detailing the complete validation algorithm)
- Receita Federal announcement: [CNPJ Alfanumérico](https://www.gov.br/receitafederal/pt-br/centrais-de-conteudo/publicacoes/perguntas-e-respostas/cnpj/cnpj-alfanumerico.pdf)

The validation algorithm uses:
- Module 11 check digit calculation
- Weights from 2 to 9 (right to left, repeating after 8th character)
- Character conversion: digits 0-9 remain as is, letters A-Z convert to values 17-42
- Check digit rule: if remainder = 0 or 1 → DV = 0, else → DV = 11 - remainder

## Checklist

- [x] PR contains only changes related; no stray files, etc.
- [ ] README updated (where applicable) - *Not applicable: no user-facing documentation changes needed*
- [x] Tests written (where applicable)
- [x] References provided in PR (where applicable)

Closes #2639