### PR TITLE
fix(isBase64): reject invalid Base64 length

### DIFF
--- a/src/lib/isBase64.js
+++ b/src/lib/isBase64.js
@@ -12,6 +12,7 @@ export default function isBase64(str, options) {
 
   if (str === '') return true;
 
+  if (str.length % 4 === 1) return false;
   if (options.padding && str.length % 4 !== 0) return false;
 
   let regex;
@@ -21,5 +22,5 @@ export default function isBase64(str, options) {
     regex = options.padding ? base64WithPadding : base64WithoutPadding;
   }
 
-  return (!options.padding || str.length % 4 === 0) && regex.test(str);
+  return regex.test(str);
 }

--- a/test/validators/isBase64.test.js
+++ b/test/validators/isBase64.test.js
@@ -26,6 +26,9 @@ describe('isBase64', () => {
         'HQIDAQAB',
       ],
       invalid: [
+        'A',
+        'AAAAA',
+        'AAAAAAAAA',
         '12345',
         'Vml2YW11cyBmZXJtZtesting123',
         'Zg=',


### PR DESCRIPTION
## Summary
- Reject strings where length % 4 === 1 (impossible in valid Base64)
- Simplify return statement by removing redundant condition

## Description
Base64 encoding always produces strings with length % 4 of 0, 2, or 3 (without padding)
Length % 4 === 1 is mathematically impossible since minimum 1 byte requires 2 Base64 characters
  | Length % 4 | With Padding | Without Padding | Reason |
  |------------|--------------|-----------------|--------|
  | 0 | ✓ Valid | ✓ Valid | Complete encoding |
  | 1 | ✗ Invalid | ✗ Invalid | Impossible - min 1 byte needs 2 chars |
  | 2 | ✗ Invalid | ✓ Valid | 1 byte encoded (padding omitted) |
  | 3 | ✗ Invalid | ✓ Valid | 2 bytes encoded (padding omitted)|


## References
- RFC 4648: https://datatracker.ietf.org/doc/html/rfc4648

## Checklist

- [X] PR contains only changes related; no stray files, etc.
- [ ] README updated (where applicable)
- [X] Tests written (where applicable)
- [X] References provided in PR (where applicable)
