### PR TITLE
fix: add .js extensions to es build for Node ESM

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,14 +46,16 @@ import validator from 'validator';
 Or, import only a subset of the library:
 
 ```javascript
-import isEmail from 'validator/lib/isEmail';
+import isEmail from 'validator/lib/isEmail.js';
 ```
 
 #### Tree-shakeable ES imports
 
 ```javascript
-import isEmail from 'validator/es/lib/isEmail';
+import isEmail from 'validator/es/lib/isEmail.js';
 ```
+
+When using native Node.js ESM, include the `.js` file extension in import specifiers.
 
 ### Client-side usage
 

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "clean": "run-p clean:*",
     "minify": "uglifyjs validator.js -o validator.min.js  --compress --mangle --comments /Copyright/",
     "build:browser": "node --require @babel/register build-browser && npm run minify",
-    "build:es": "babel src -d es --env-name=es",
+    "build:es": "babel src -d es --env-name=es && node scripts/add-es-import-extensions.js",
     "build:node": "babel src -d .",
     "build": "run-p build:*",
     "pretest": "npm run build && npm run lint",

--- a/scripts/add-es-import-extensions.js
+++ b/scripts/add-es-import-extensions.js
@@ -1,0 +1,41 @@
+const fs = require('fs');
+const path = require('path');
+
+const ES_ROOT = path.join(__dirname, '..', 'es');
+
+function addExtension(specifier) {
+  if (specifier.endsWith('.js')) {
+    return specifier;
+  }
+
+  return `${specifier}.js`;
+}
+
+function fixFile(filePath) {
+  const source = fs.readFileSync(filePath, 'utf8');
+  const updated = source.replace(
+    /from ['"](\.\.?\/[^'"]+)['"]/g,
+    (match, specifier) => match.replace(specifier, addExtension(specifier)),
+  );
+
+  if (updated !== source) {
+    fs.writeFileSync(filePath, updated);
+  }
+}
+
+function walk(directory) {
+  for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+    const entryPath = path.join(directory, entry.name);
+
+    if (entry.isDirectory()) {
+      walk(entryPath);
+      continue;
+    }
+
+    if (entry.name.endsWith('.js')) {
+      fixFile(entryPath);
+    }
+  }
+}
+
+walk(ES_ROOT);

--- a/scripts/add-es-import-extensions.js
+++ b/scripts/add-es-import-extensions.js
@@ -24,15 +24,15 @@ function fixFile(filePath) {
 }
 
 function walk(directory) {
-  for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
-    const entryPath = path.join(directory, entry.name);
+  for (const entryName of fs.readdirSync(directory)) {
+    const entryPath = path.join(directory, entryName);
 
-    if (entry.isDirectory()) {
+    if (fs.statSync(entryPath).isDirectory()) {
       walk(entryPath);
       continue;
     }
 
-    if (entry.name.endsWith('.js')) {
+    if (entryName.endsWith('.js')) {
       fixFile(entryPath);
     }
   }


### PR DESCRIPTION
## Summary

Fixes #2528

Node ESM requires explicit `.js` extensions on relative imports. The `es/` build output currently emits imports like `from './util/assertString'` without extensions, causing `ERR_MODULE_NOT_FOUND` when importing individual validators in Node.

This adds a post-build step (`scripts/add-es-import-extensions.js`) that runs after `babel` in `build:es` and appends `.js` to relative import/export paths in the generated `es/` tree.

Also updates README examples to use the correct `.js` paths for both CommonJS and ESM.

## Test plan

- [x] `npm run build:es` completes successfully
- [x] Node ESM import of `./es/lib/isEmail.js` works
- [x] `npm test` — 318 tests passing