### PR TITLE
fix(isJWT): reject tokens with non-JSON header or payload

### DIFF
--- a/src/lib/isJWT.js
+++ b/src/lib/isJWT.js
@@ -11,10 +11,10 @@ function isBase64EncodedJSON(base64Str) {
     try {
       JSON.parse(decoded);
       return true;
-    } catch {
+    } catch (_err) {
       return false;
     }
-  } catch {
+  } catch (_err) {
     return false;
   }
 }

--- a/src/lib/isJWT.js
+++ b/src/lib/isJWT.js
@@ -1,6 +1,24 @@
 import assertString from './util/assertString';
 import isBase64 from './isBase64';
 
+function isBase64EncodedJSON(base64Str) {
+  // Convert URL-safe base64 to standard base64
+  const standardBase64 = base64Str.replace(/-/g, '+').replace(/_/g, '/');
+  try {
+    const decoded = typeof globalThis.atob === 'function'
+      ? globalThis.atob(standardBase64)
+      : Buffer.from(standardBase64, 'base64').toString('binary');
+    try {
+      JSON.parse(decoded);
+      return true;
+    } catch {
+      return false;
+    }
+  } catch {
+    return false;
+  }
+}
+
 export default function isJWT(str) {
   assertString(str);
 
@@ -11,5 +29,14 @@ export default function isJWT(str) {
     return false;
   }
 
-  return dotSplit.reduce((acc, currElem) => acc && isBase64(currElem, { urlSafe: true }), true);
+  const [header, payload, signature] = dotSplit;
+
+  if (!isBase64(header, { urlSafe: true }) ||
+      !isBase64(payload, { urlSafe: true }) ||
+      !isBase64(signature, { urlSafe: true })) {
+    return false;
+  }
+
+  // header and payload must be valid JSON when decoded
+  return isBase64EncodedJSON(header) && isBase64EncodedJSON(payload);
 }

--- a/src/lib/isJWT.js
+++ b/src/lib/isJWT.js
@@ -1,29 +1,26 @@
 import assertString from './util/assertString';
 import isBase64 from './isBase64';
 
-function getGlobalScope() {
-  if (typeof globalThis !== 'undefined') return globalThis;
+var getGlobal = function() {
+  if (typeof global !== 'undefined') return global;
   if (typeof self !== 'undefined') return self;
   if (typeof window !== 'undefined') return window;
-  if (typeof global !== 'undefined') return global;
   return {};
-}
+}();
 
 function isBase64EncodedJSON(base64Str) {
-  // Convert URL-safe base64 to standard base64
-  const standardBase64 = base64Str.replace(/-/g, '+').replace(/_/g, '/');
+  var standardBase64 = base64Str.replace(/-/g, '+').replace(/_/g, '/');
   try {
-    const scope = getGlobalScope();
-    const decoded = typeof scope.atob === 'function'
-      ? scope.atob(standardBase64)
+    var decoded = typeof getGlobal.atob === 'function'
+      ? getGlobal.atob(standardBase64)
       : Buffer.from(standardBase64, 'base64').toString('binary');
     try {
       JSON.parse(decoded);
       return true;
-    } catch (_err) {
+    } catch (e2) {
       return false;
     }
-  } catch (_err) {
+  } catch (e) {
     return false;
   }
 }
@@ -31,14 +28,16 @@ function isBase64EncodedJSON(base64Str) {
 export default function isJWT(str) {
   assertString(str);
 
-  const dotSplit = str.split('.');
-  const len = dotSplit.length;
+  var dotSplit = str.split('.');
+  var len = dotSplit.length;
 
   if (len !== 3) {
     return false;
   }
 
-  const [header, payload, signature] = dotSplit;
+  var header = dotSplit[0];
+  var payload = dotSplit[1];
+  var signature = dotSplit[2];
 
   if (!isBase64(header, { urlSafe: true }) ||
       !isBase64(payload, { urlSafe: true }) ||
@@ -46,6 +45,5 @@ export default function isJWT(str) {
     return false;
   }
 
-  // header and payload must be valid JSON when decoded
   return isBase64EncodedJSON(header) && isBase64EncodedJSON(payload);
 }

--- a/src/lib/isJWT.js
+++ b/src/lib/isJWT.js
@@ -1,12 +1,21 @@
 import assertString from './util/assertString';
 import isBase64 from './isBase64';
 
+function getGlobalScope() {
+  if (typeof globalThis !== 'undefined') return globalThis;
+  if (typeof self !== 'undefined') return self;
+  if (typeof window !== 'undefined') return window;
+  if (typeof global !== 'undefined') return global;
+  return {};
+}
+
 function isBase64EncodedJSON(base64Str) {
   // Convert URL-safe base64 to standard base64
   const standardBase64 = base64Str.replace(/-/g, '+').replace(/_/g, '/');
   try {
-    const decoded = typeof globalThis.atob === 'function'
-      ? globalThis.atob(standardBase64)
+    const scope = getGlobalScope();
+    const decoded = typeof scope.atob === 'function'
+      ? scope.atob(standardBase64)
       : Buffer.from(standardBase64, 'base64').toString('binary');
     try {
       JSON.parse(decoded);

--- a/src/lib/isJWT.js
+++ b/src/lib/isJWT.js
@@ -1,18 +1,20 @@
 import assertString from './util/assertString';
 import isBase64 from './isBase64';
 
-var getGlobal = function() {
+function getGlobalScope() {
   if (typeof global !== 'undefined') return global;
   if (typeof self !== 'undefined') return self;
   if (typeof window !== 'undefined') return window;
   return {};
-}();
+}
 
 function isBase64EncodedJSON(base64Str) {
-  var standardBase64 = base64Str.replace(/-/g, '+').replace(/_/g, '/');
+  // Convert URL-safe base64 to standard base64
+  const standardBase64 = base64Str.replace(/-/g, '+').replace(/_/g, '/');
   try {
-    var decoded = typeof getGlobal.atob === 'function'
-      ? getGlobal.atob(standardBase64)
+    const scope = getGlobalScope();
+    const decoded = typeof scope.atob === 'function'
+      ? scope.atob(standardBase64)
       : Buffer.from(standardBase64, 'base64').toString('binary');
     try {
       JSON.parse(decoded);
@@ -28,22 +30,21 @@ function isBase64EncodedJSON(base64Str) {
 export default function isJWT(str) {
   assertString(str);
 
-  var dotSplit = str.split('.');
-  var len = dotSplit.length;
+  const dotSplit = str.split('.');
+  const len = dotSplit.length;
 
   if (len !== 3) {
     return false;
   }
 
-  var header = dotSplit[0];
-  var payload = dotSplit[1];
-  var signature = dotSplit[2];
+  const [header, payload, signature] = dotSplit;
 
-  if (!isBase64(header, { urlSafe: true }) ||
-      !isBase64(payload, { urlSafe: true }) ||
-      !isBase64(signature, { urlSafe: true })) {
+  if (!isBase64(header, { urlSafe: true })
+      || !isBase64(payload, { urlSafe: true })
+      || !isBase64(signature, { urlSafe: true })) {
     return false;
   }
 
+  // header and payload must be valid JSON when decoded
   return isBase64EncodedJSON(header) && isBase64EncodedJSON(payload);
 }

--- a/test/validators.test.js
+++ b/test/validators.test.js
@@ -5549,6 +5549,10 @@ describe('Validators', () => {
         'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NSIsIm5hbWUiOiJKb2huIERvZSIsImlhdCI6MTYxNjY1Mzg3Mn0.eyJpc3MiOiJodHRwczovL2V4YW1wbGUuY29tIiwiaWF0IjoxNjE2NjUzODcyLCJleHAiOjE2MTY2NTM4ODJ9.a1jLRQkO5TV5y5ERcaPAiM9Xm2gBdRjKrrCpHkGr_8M',
         '$Zs.ewu.su84',
         'ks64$S/9.dy$§kz.3sd73b',
+        // non-JSON header (valid base64 URL-safe but not valid JSON when decoded)
+        'ZmFrZSBoZWFkZXI.eyJzdWIiOiIxMjM0NTY3ODkwIn0.ZmFrZXNpZw',
+        // non-JSON payload (valid base64 URL-safe but not valid JSON)
+        'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.bm9uLWpzb24tcGF5bG9hZA.sig',
       ],
       error: [
         [],


### PR DESCRIPTION
### Description

The `isJWT` function currently only validates that a string has three dot-separated segments and that each segment is valid URL-safe base64. However, a JWT's header and payload must be valid JSON when decoded.

For example:
```js
isJWT("foo.bar.dGVzdA"); // Currently true, but should be false
```

The string "foo" is valid base64 but is not valid JSON, meaning this is not a real JWT.

### Changes
- Decode the header and payload base64 segments and parse as JSON
- Return false if either is not valid JSON

### Related Issue
Fixes #2511