### PR TITLE
fix(isISO8601): pad year to 4 digits in strict validation for years < 1000

### DIFF
--- a/src/lib/isISO8601.js
+++ b/src/lib/isISO8601.js
@@ -27,7 +27,9 @@ const isValidDate = (str) => {
   const dayString = day ? `0${day}`.slice(-2) : day;
 
   // create a date object and compare
-  const d = new Date(`${year}-${monthString || '01'}-${dayString || '01'}`);
+  // pad year to 4 digits to avoid Date() parsing ambiguity for years < 1000
+  const yearString = `${year}`.padStart(4, '0');
+  const d = new Date(`${yearString}-${monthString || '01'}-${dayString || '01'}`);
   if (month && day) {
     return d.getUTCFullYear() === year
       && (d.getUTCMonth() + 1) === month


### PR DESCRIPTION
### Description

When `isISO8601` is called with `strict: true`, the `isValidDate` function extracts the year via `Number()`, which converts leading-zero years like `0001` to `1`. The year is then interpolated directly into the date string passed to `new Date()`.

For example, `1-01-13` is interpreted by JavaScript as January 13th 2001 instead of January 13th 0001, causing the `getUTCFullYear()` comparison to fail.

### Changes
- Pad the year to 4 digits using `padStart(4, '0')` before constructing the date string
- This ensures correct Date parsing for all year values (1-9999)

### Related Issue
Fixes #2517