### PR TITLE
fix(isFQDN): skip numeric-label check when require_tld is false

### DIFF
--- a/src/lib/isFQDN.js
+++ b/src/lib/isFQDN.js
@@ -43,8 +43,8 @@ export default function isFQDN(str, options) {
     }
   }
 
-  // reject numeric TLDs
-  if (!options.allow_numeric_tld && /^\d+$/.test(tld)) {
+  // reject numeric TLDs (only when a TLD is actually required)
+  if (options.require_tld && !options.allow_numeric_tld && /^\d+$/.test(tld)) {
     return false;
   }
 

--- a/test/validators/isFQDN.test.js
+++ b/test/validators/isFQDN.test.js
@@ -22,5 +22,18 @@ describe('isFQDN', () => {
       invalid: [
       ],
     });
+    test({
+      validator: 'isFQDN',
+      args: [{ require_tld: false }],
+      valid: [
+        'google.com',
+        'localhost',
+        '192',
+        '10',
+      ],
+      invalid: [
+        '',
+      ],
+    });
   });
 });


### PR DESCRIPTION
## Problem

When `require_tld: false`, single-label names that are all-numeric (e.g. `192`, `10`) are incorrectly rejected by `isFQDN`.

```js
isFQDN('192', { require_tld: false })  // returns false  ❌ (should be true)
isFQDN('10',  { require_tld: false })  // returns false  ❌ (should be true)
```

**Root cause:** The check at line 47 (outside the `require_tld` block) was unconditionally rejecting any label whose last dot-segment consists solely of digits:

```js
// before
if (!options.allow_numeric_tld && /^\d+$/.test(tld)) {
  return false;
}
```

When `require_tld: true` this is fine — TLDs like `.123` are always disallowed. But when `require_tld: false` there is no TLD at all; the last segment is just the only label, and a purely numeric label should be permitted.

The same constraint is already enforced inside the `require_tld` block (line 36 rejects non-alphabetic TLDs), so the outer check is redundant for the `require_tld: true` case and harmful for the `require_tld: false` case.

## Fix

Guard the check with `options.require_tld`:

```js
// after
if (options.require_tld && !options.allow_numeric_tld && /^\d+$/.test(tld)) {
  return false;
}
```

## Tests

Added test cases for `{ require_tld: false }` in `test/validators/isFQDN.test.js` covering:
- Standard multi-label FQDNs (`google.com`) still pass
- Non-numeric single labels (`localhost`) pass
- Numeric single labels (`192`, `10`) now correctly pass

Fixes #2425