### PR TITLE
fix(isISO6346): anchor regex alternation and remove stray comma

### DIFF
--- a/src/lib/isISO6346.js
+++ b/src/lib/isISO6346.js
@@ -3,7 +3,7 @@ import assertString from './util/assertString';
 // https://en.wikipedia.org/wiki/ISO_6346
 // according to ISO6346 standard, checksum digit is mandatory for freight container but recommended
 // for other container types (J and Z)
-const isISO6346Str = /^[A-Z]{3}(U[0-9]{7})|([J,Z][0-9]{6,7})$/;
+const isISO6346Str = /^[A-Z]{3}(U[0-9]{7}|[JZ][0-9]{6,7})$/;
 const isDigit = /^[0-9]$/;
 
 export function isISO6346(str) {

--- a/test/validators.test.js
+++ b/test/validators.test.js
@@ -13537,6 +13537,9 @@ describe('Validators', () => {
         'ECMJ4657496',
         'TBJA7176445',
         'AFFU5962593',
+        'ABCU1234567GARBAGE', // trailing garbage after a valid prefix
+        'GARBAGEZ123456', // leading garbage before a valid suffix
+        'XYZ,123456', // comma is not a valid category identifier
       ],
     });
   });
@@ -13562,6 +13565,9 @@ describe('Validators', () => {
         'ECMJ4657496',
         'TBJA7176445',
         'AFFU5962593',
+        'ABCU1234567GARBAGE', // trailing garbage after a valid prefix
+        'GARBAGEZ123456', // leading garbage before a valid suffix
+        'XYZ,123456', // comma is not a valid category identifier
       ],
     });
   });


### PR DESCRIPTION
The `isISO6346` validator accepts strings it should reject because of an un-grouped regex alternation.

## The bug

```js
const isISO6346Str = /^[A-Z]{3}(U[0-9]{7})|([J,Z][0-9]{6,7})$/;
```

`|` has the lowest precedence, and the two branches are not wrapped in a group, so the pattern actually parses as:

```
(^[A-Z]{3}(U[0-9]{7}))   OR   (([J,Z][0-9]{6,7})$)
```

The first branch is anchored only at the **start** and the second only at the **end**. As a result:

- a valid prefix followed by arbitrary trailing characters matches the first branch, and
- arbitrary leading characters followed by a valid suffix match the second branch.

Additionally, the character class `[J,Z]` matches a literal comma, which is never a valid ISO 6346 category identifier.

## Reproduction

```js
const validator = require("validator");

validator.isISO6346("ABCU1234567GARBAGE"); // => true  (expected false)
validator.isISO6346("GARBAGEZ123456");     // => true  (expected false)
validator.isISO6346("XYZ,123456");         // => true  (expected false)
```

These all return `true` today. Because the checksum block only runs when `str.length === 11`, the un-anchored false positives bypass validation entirely.

## The fix

Wrap the alternation in the existing group and drop the stray comma, so the whole string is anchored:

```js
const isISO6346Str = /^[A-Z]{3}(U[0-9]{7}|[JZ][0-9]{6,7})$/;
```

This is the same class of fix already applied to other anchored-alternation validators in this project.

## Tests

- Added regression cases (`ABCU1234567GARBAGE`, `GARBAGEZ123456`, `XYZ,123456`) to the `isISO6346` / `isFreightContainerID` invalid lists.
- All existing valid cases (including the `J`/`Z` short forms like `QJRZ123456`) still pass.
- Full validators suite passes (249 passing) and `eslint src test` is clean.