### PR TITLE
fix(isISO6346): anchor full pattern and drop stray comma

### DIFF
--- a/src/lib/isISO6346.js
+++ b/src/lib/isISO6346.js
@@ -3,7 +3,7 @@ import assertString from './util/assertString';
 // https://en.wikipedia.org/wiki/ISO_6346
 // according to ISO6346 standard, checksum digit is mandatory for freight container but recommended
 // for other container types (J and Z)
-const isISO6346Str = /^[A-Z]{3}(U[0-9]{7})|([J,Z][0-9]{6,7})$/;
+const isISO6346Str = /^[A-Z]{3}(U[0-9]{7}|[JZ][0-9]{6,7})$/;
 const isDigit = /^[0-9]$/;
 
 export function isISO6346(str) {

--- a/test/validators.test.js
+++ b/test/validators.test.js
@@ -13537,6 +13537,10 @@ describe('Validators', () => {
         'ECMJ4657496',
         'TBJA7176445',
         'AFFU5962593',
+        'ABCU1234567HELLO',
+        'CSQU3054383XXX',
+        'hellozZ123456',
+        'AB,123456',
       ],
     });
   });
@@ -13562,6 +13566,10 @@ describe('Validators', () => {
         'ECMJ4657496',
         'TBJA7176445',
         'AFFU5962593',
+        'ABCU1234567HELLO',
+        'CSQU3054383XXX',
+        'hellozZ123456',
+        'AB,123456',
       ],
     });
   });


### PR DESCRIPTION
Fixes #2772.

The regex in `src/lib/isISO6346.js` did not group the alternation, so `^` anchored only the first branch and `$` only the second. The first branch matched any string starting with the owner prefix, `U` and 7 digits while ignoring trailing characters; the second matched any string ending with `J`/`Z` and 6-7 digits while ignoring the leading owner prefix. `[J,Z]` also accepted a literal comma. Strings whose length is not 11 skip the checksum and return `true`, so these malformed inputs passed.

```js
isISO6346('ABCU1234567HELLO'); // was true
isISO6346('CSQU3054383XXX');   // was true
isISO6346('hellozZ123456');    // was true
isISO6346('AB,123456');        // was true
```

The fix groups the alternation inside the anchors and uses `[JZ]`:

```js
const isISO6346Str = /^[A-Z]{3}(U[0-9]{7}|[JZ][0-9]{6,7})$/;
```

All existing valid and invalid fixtures still pass. Added the four cases above to the invalid fixtures for both `isISO6346` and `isFreightContainerID`; they fail on the previous regex and pass with the fix.