### PR TITLE
fix(isBtcAddress): accept 62-character bech32 P2WSH addresses

### DIFF
--- a/src/lib/isBtcAddress.js
+++ b/src/lib/isBtcAddress.js
@@ -1,6 +1,6 @@
 import assertString from './util/assertString';
 
-const bech32 = /^(bc1|tb1|bc1p|tb1p)[ac-hj-np-z02-9]{39,58}$/;
+const bech32 = /^(bc1|tb1|bc1p|tb1p)[ac-hj-np-z02-9]{39,59}$/;
 const base58 = /^(1|2|3|m)[A-HJ-NP-Za-km-z1-9]{25,39}$/;
 
 export default function isBtcAddress(str) {

--- a/test/validators.test.js
+++ b/test/validators.test.js
@@ -12217,9 +12217,12 @@ describe('Validators', () => {
         'tb1qxhkl607frtvjsy9nlyeg03lf6fsq947pl2pe82',
         'bc1p5d7rjq7g6rdk2yhzks9smlaqtedr4dekq08ge8ztwac72sfr9rusxg3297',
         'tb1pzpelffrdh9ptpaqnurwx30dlewqv57rcxfeetp86hsssk30p4cws38tr9y',
+        'bc1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3qccfmv3',
+        'tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sl5k7',
       ],
       invalid: [
         '3J98t1WpEZ73CNmQviecrnyiWrnqh0WNL0',
+        'bc1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3qccfmv3q',
         '3J98t1WpEZ73CNmQviecrnyiWrnqh0WNLo',
         '3J98t1WpEZ73CNmQviecrnyiWrnqh0WNLI',
         '3J98t1WpEZ73CNmQviecrnyiWrnqh0WNLl',


### PR DESCRIPTION
isBtcAddress rejects valid native SegWit **P2WSH** addresses (62 characters), including the official BIP-173 test vectors.

## Problem

The bech32 pattern caps the data part after the `bc1`/`tb1` prefix at 58 characters:

```js
const bech32 = /^(bc1|tb1|bc1p|tb1p)[ac-hj-np-z02-9]{39,58}$/;
```

A bech32 address is `HRP` + `1` + data, where the data part is `1` (witness version) + program (squashed to base32) + `6` (checksum). For a witness-v0 program:

| Type   | Program | base32 program chars | Data part (`1 + prog + 6`) | Total |
|--------|---------|----------------------|----------------------------|-------|
| P2WPKH | 20 bytes | `ceil(20*8/5) = 32` | **39** | 42 |
| P2WSH  | 32 bytes | `ceil(32*8/5) = 52` | **59** | 62 |

P2WPKH sits exactly at the lower bound (39) and passes, but **P2WSH needs 59 data characters and is cut off by the `{39,58}` upper bound**, so every 62-char v0 address fails. (P2TR/taproot is also 62 chars but only matched today by accident — its 4th char `p` lets the regex backtrack into the `bc1p` alternative.)

## Reproduction

```js
const validator = require(validator);

// Official BIP-173 P2WSH test vectors:
validator.isBtcAddress(bc1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3qccfmv3); // false, expected true
validator.isBtcAddress(tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sl5k7); // false, expected true
```

## Fix

Bump the upper bound from `58` to `59` so a v0 32-byte (P2WSH) address matches. The upper limit is still enforced — a 60-data-char string is added to the invalid fixtures to guard against regression.

```diff
-const bech32 = /^(bc1|tb1|bc1p|tb1p)[ac-hj-np-z02-9]{39,58}$/;
+const bech32 = /^(bc1|tb1|bc1p|tb1p)[ac-hj-np-z02-9]{39,59}$/;
```

## Authoritative source

- **BIP-173 (Base32 address format for native v0-16 witness outputs)** — the two addresses above are the canonical P2WSH **test vectors** listed in the spec: https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki#examples
- **BIP-141** defines the witness program length (2–40 bytes), giving the 32-byte P2WSH case.

## Tests

Added the two BIP-173 P2WSH vectors to `valid` and an over-length (60 data chars) string to `invalid` in `test/validators.test.js`. The new valid cases fail before the fix and pass after; full suite (`npm test`) is green with coverage unchanged.