### PR TITLE
reject empty and at-sign-less input in normalizeEmail

### DIFF
--- a/src/lib/normalizeEmail.js
+++ b/src/lib/normalizeEmail.js
@@ -173,6 +173,12 @@ export default function normalizeEmail(email, options) {
   options = merge(options, default_normalize_email_options);
 
   const raw_parts = email.split('@');
+  // Reject addresses without an '@' or with an empty local part.
+  // raw_parts.pop() below would otherwise turn '' into ('@','') and 'foo' into ('@','foo').
+  if (raw_parts.length < 2 || raw_parts.slice(0, -1).join('@') === '') {
+    return false;
+  }
+
   const domain = raw_parts.pop();
   const user = raw_parts.join('@');
   const parts = [user, domain];

--- a/test/sanitizers.test.js
+++ b/test/sanitizers.test.js
@@ -313,6 +313,8 @@ describe('Sanitizers', () => {
         '@icloud.com': false,
         '@outlook.com': false,
         '@yahoo.com': false,
+        '': false,
+        'no-at-sign': false,
       },
     });
 


### PR DESCRIPTION
normalizeEmail('') returned '@' and normalizeEmail('foo') returned '@foo' because the function unconditionally ran `raw_parts.pop()` and joined the remaining segments as the local part. When the input has no '@' (or every part before the last is empty), the result is a malformed address with no warning.

This change rejects those cases up front so they return `false`, consistent with how the per-domain branches already return `false` for an empty local part (e.g. `'@gmail.com': false`). Two new expectations have been added to the sanitizer test to lock the behavior in.

```js
normalizeEmail('')          // before: '@'    after: false
normalizeEmail('no-at')     // before: '@no-at' after: false
normalizeEmail('@gmail.com')// before: false  after: false (unchanged)
normalizeEmail('a@b@c')     // before: 'a@b@c' after: 'a@b@c' (unchanged — valid)
```