### PR TITLE
parse the input as a number in isInt before comparing against min/max/lt/gt

### DIFF
--- a/src/lib/isInt.js
+++ b/src/lib/isInt.js
@@ -12,11 +12,26 @@ export default function isInt(str, options) {
   // leading zeroes are allowed or not.
   const regex = options.allow_leading_zeroes === false ? int : intLeadingZeroes;
 
-  // Check min/max/lt/gt
-  let minCheckPassed = (!options.hasOwnProperty('min') || isNullOrUndefined(options.min) || str >= options.min);
-  let maxCheckPassed = (!options.hasOwnProperty('max') || isNullOrUndefined(options.max) || str <= options.max);
-  let ltCheckPassed = (!options.hasOwnProperty('lt') || isNullOrUndefined(options.lt) || str < options.lt);
-  let gtCheckPassed = (!options.hasOwnProperty('gt') || isNullOrUndefined(options.gt) || str > options.gt);
+  if (!regex.test(str)) {
+    return false;
+  }
 
-  return regex.test(str) && minCheckPassed && maxCheckPassed && ltCheckPassed && gtCheckPassed;
+  // Compare numerically, not lexically. With `str >= options.min` (where
+  // options.min is a number) JavaScript coerces `str` to a number for the
+  // comparison, but the coercion is only performed one side at a time and a
+  // future refactor that calls e.g. `String.prototype.localeCompare` or
+  // `>=` between two strings would silently break — and the existing code
+  // also mishandles negative bounds (`str >= -5` still works but `str
+  // >= options.min` with options.min being a positive integer is the
+  // only path currently exercised). Parsing here keeps the comparison
+  // explicit and avoids any future string-comparison footgun.
+  const num = Number(str);
+
+  // Check min/max/lt/gt against the numeric value.
+  let minCheckPassed = (!options.hasOwnProperty('min') || isNullOrUndefined(options.min) || num >= options.min);
+  let maxCheckPassed = (!options.hasOwnProperty('max') || isNullOrUndefined(options.max) || num <= options.max);
+  let ltCheckPassed = (!options.hasOwnProperty('lt') || isNullOrUndefined(options.lt) || num < options.lt);
+  let gtCheckPassed = (!options.hasOwnProperty('gt') || isNullOrUndefined(options.gt) || num > options.gt);
+
+  return minCheckPassed && maxCheckPassed && ltCheckPassed && gtCheckPassed;
 }

--- a/test/validators.test.js
+++ b/test/validators.test.js
@@ -4628,6 +4628,69 @@ describe('Validators', () => {
         '111987234i',
       ],
     });
+
+    // Regression: when the user passes a STRING for min/max/lt/gt (e.g.
+    // a value from a form POST body, a query string, or a JSON payload
+    // where the schema did not coerce numeric fields), the previous
+    // implementation did `str <= options.max` which is a string-vs-string
+    // comparison. `'100' <= '9'` is true because '1' < '9' lexicographically.
+    // Numeric parsing of both sides makes the bound checks robust.
+    test({
+      validator: 'isInt',
+      args: [{
+        max: '9',
+      }],
+      valid: [
+        '5',
+        '8',
+        '9',
+      ],
+      invalid: [
+        '10',
+        '50',
+        '99',
+        '100',
+        '1000',
+      ],
+    });
+    test({
+      validator: 'isInt',
+      args: [{
+        min: '5',
+        max: '9',
+      }],
+      valid: [
+        '5',
+        '6',
+        '9',
+      ],
+      invalid: [
+        '4',
+        '10',
+        '99',
+        '100',
+        '1000',
+      ],
+    });
+    test({
+      validator: 'isInt',
+      args: [{
+        gt: '1',
+        lt: '9',
+      }],
+      valid: [
+        '2',
+        '8',
+      ],
+      invalid: [
+        '1',
+        '9',
+        '10',
+        '99',
+        '100',
+      ],
+    });
+
   });
 
   it('should validate floats', () => {


### PR DESCRIPTION
The previous implementation did `str >= options.min` (and the symmetric
`str <= options.max`, `str < options.lt`, `str > options.gt`). When the
caller passes a numeric value for the bound this still works because
JS coerces `str` to a number, but when the bound is a string (e.g. an
uncoerced value from a form POST body, a query string, or a JSON
payload) the comparison falls back to string-vs-string lexicographic
order. `'100' <= '9'` is true because '1' < '9' in code-point order, so
isInt('100', { max: '9' }) returned true — any caller using a string
bound (or any framework that hands the option through a non-coercing
typed schema) got silently wrong results.

Parse `str` as a number once and compare numerically on both sides; an
early `return false` when the integer regex doesn't match also avoids
the now-impossible `Number(non_integer)` → NaN silently failing the
>= comparison (NaN compared with anything is false, so this previously
worked by accident).

Added 3 isInt test cases covering string-form max, string-form
min+max, and string-form gt+lt to lock in the numeric-order behaviour.
