### PR TITLE
fix(isPassportNumber): anchor MZ and PH alternations

### DIFF
--- a/src/lib/isPassportNumber.js
+++ b/src/lib/isPassportNumber.js
@@ -48,12 +48,12 @@ const passportRegexByCountryCode = {
   LV: /^[A-Z0-9]{2}\d{7}$/, // LATVIA
   LY: /^[A-Z0-9]{8}$/, // LIBYA
   MT: /^\d{7}$/, // MALTA
-  MZ: /^([A-Z]{2}\d{7})|(\d{2}[A-Z]{2}\d{5})$/, // MOZAMBIQUE
+  MZ: /^([A-Z]{2}\d{7}|\d{2}[A-Z]{2}\d{5})$/, // MOZAMBIQUE
   MY: /^[AHK]\d{8}$/, // MALAYSIA
   MX: /^[A-Z]\d{8}$/, // MEXICO
   NL: /^[A-Z]{2}[A-Z0-9]{6}\d$/, // NETHERLANDS
   NZ: /^([Ll]([Aa]|[Dd]|[Ff]|[Hh])|[Ee]([Aa]|[Pp])|[Nn])\d{6}$/, // NEW ZEALAND
-  PH: /^([A-Z](\d{6}|\d{7}[A-Z]))|([A-Z]{2}(\d{6}|\d{7}))$/, // PHILIPPINES
+  PH: /^([A-Z](\d{6}|\d{7}[A-Z])|[A-Z]{2}(\d{6}|\d{7}))$/, // PHILIPPINES
   PK: /^[A-Z]{2}\d{7}$/, // PAKISTAN
   PL: /^[A-Z]{2}\d{7}$/, // POLAND
   PT: /^[A-Z]\d{6}$/, // PORTUGAL

--- a/test/validators.test.js
+++ b/test/validators.test.js
@@ -3786,6 +3786,8 @@ describe('Validators', () => {
         '1AB011241',
         '1AB01121',
         'ABAB01121',
+        'AB0808212XXXX',
+        'ZZZZ08AB12123',
       ],
     });
     test({
@@ -3855,6 +3857,8 @@ describe('Validators', () => {
         'XY12345',
         'X12345Z',
         'XY12345Z',
+        'X123456ZZZ',
+        'ZZZXY123456',
       ],
     });
 


### PR DESCRIPTION
The Mozambique and Philippines passport patterns put the `|` outside the anchors, so `^` only applied to the first branch and `$` only to the last. That meant any extra characters before or after a valid number slipped through:

```js
isPassportNumber('AB0808212XXXX', 'MZ'); // true, should be false
isPassportNumber('ZZZZ08AB12123', 'MZ'); // true, should be false
isPassportNumber('X123456ZZZ', 'PH');    // true, should be false
isPassportNumber('ZZZXY123456', 'PH');   // true, should be false
```

Wrapping each alternation in a group so both anchors bind to every branch — same shape as the CA/CN/EE entries already use. All the existing valid/invalid fixtures still behave the same; I added the junk-padded cases above to the MZ and PH tests so the regression is covered.