### PR TITLE
fix(isByteLength): default min to 0 in the legacy positional signature

### DIFF
--- a/src/lib/isByteLength.js
+++ b/src/lib/isByteLength.js
@@ -9,7 +9,7 @@ export default function isByteLength(str, options) {
     min = options.min || 0;
     max = options.max;
   } else { // backwards compatibility: isByteLength(str, min [, max])
-    min = arguments[1];
+    min = arguments[1] || 0;
     max = arguments[2];
   }
   const len = encodeURI(str).split(/%..|./).length - 1;

--- a/test/validators.test.js
+++ b/test/validators.test.js
@@ -5727,6 +5727,12 @@ describe('Validators', () => {
       valid: [''],
       invalid: ['ｇ', 'a'],
     });
+    test({
+      validator: 'isByteLength',
+      args: [undefined, 3],
+      valid: ['abc', 'de', 'ｇ', 'a', ''],
+      invalid: ['abcd', 'ｇｍ'],
+    });
   });
 
 


### PR DESCRIPTION
`isByteLength` accepts two signatures: the object form `isByteLength(str, { min, max })` and the legacy positional form `isByteLength(str, min, max)`.

The object branch defaults `min` to 0 (`options.min || 0`), but the legacy branch used `min = arguments[1]` with no default. When `min` is omitted there, it stays `undefined`, so the final `len >= min` check becomes `len >= NaN` and always returns `false`.

The README documents the default as `{ min: 0, max: undefined }`, and the sibling `isLength` already uses `arguments[1] || 0` in the same legacy branch, so this only affected `isByteLength`.

Before:
- `isByteLength('abc')` returned `false`
- `isByteLength('abc', undefined, 3)` returned `false`

After, both return `true`, matching `isByteLength('abc', { max: 3 })` which was already correct.

Added a case to the existing deprecated-api test block, mirroring the `{ max: 3 }` object test that was already there.

## Checklist

- [x] PR contains only changes related; no stray files, etc.
- [ ] README updated (where applicable)
- [x] Tests written (where applicable)
- [ ] References provided in PR (where applicable)
