### PR TITLE
feat: add ja-JP license plate validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Validator                               | Description
 **isJWT(str)**                          | check if the string is valid JWT token.
 **isLatLong(str [, options])**          | check if the string is a valid latitude-longitude coordinate in the format `lat,long` or `lat, long`.<br/><br/>`options` is an object that defaults to `{ checkDMS: false }`. Pass `checkDMS` as `true` to validate DMS(degrees, minutes, and seconds) latitude-longitude format.
 **isLength(str [, options])**           | check if the string's length falls in a range and equal to any of the integers of the `discreteLengths` array if provided.<br/><br/>`options` is an object which defaults to `{ min: 0, max: undefined, discreteLengths: undefined }`. Note: this function takes into account surrogate pairs.
-**isLicensePlate(str, locale)**         | check if the string matches the format of a country's license plate.<br/><br/>`locale` is one of `['cs-CZ', 'de-DE', 'de-LI', 'en-IN', 'en-SG', 'en-PK', 'es-AR', 'hu-HU', 'pt-BR', 'pt-PT', 'sq-AL', 'sv-SE']` or `'any'`.
+**isLicensePlate(str, locale)**         | check if the string matches the format of a country's license plate.<br/><br/>`locale` is one of `['cs-CZ', 'de-DE', 'de-LI', 'en-IN', 'en-SG', 'en-PK', 'es-AR', 'hu-HU', 'ja-JP', 'pt-BR', 'pt-PT', 'sq-AL', 'sv-SE']` or `'any'`.
 **isLocale(str)**                       | check if the string is a locale.
 **isLowercase(str)**                    | check if the string is lowercase.
 **isLuhnNumber(str)**                    | check if the string passes the [Luhn algorithm check](https://en.wikipedia.org/wiki/Luhn_algorithm).

--- a/src/lib/isLicensePlate.js
+++ b/src/lib/isLicensePlate.js
@@ -11,6 +11,7 @@ const validators = {
   'es-AR': str => /^(([A-Z]{2} ?[0-9]{3} ?[A-Z]{2})|([A-Z]{3} ?[0-9]{3}))$/.test(str),
   'fi-FI': str => /^(?=.{4,7})(([A-Z]{1,3}|[0-9]{1,3})[\s-]?([A-Z]{1,3}|[0-9]{1,5}))$/.test(str),
   'hu-HU': str => /^((((?!AAA)(([A-NPRSTVZWXY]{1})([A-PR-Z]{1})([A-HJ-NPR-Z]))|(A[ABC]I)|A[ABC]O|A[A-W]Q|BPI|BPO|UCO|UDO|XAO)-(?!000)\d{3})|(M\d{6})|((CK|DT|CD|HC|H[ABEFIKLMNPRSTVX]|MA|OT|R[A-Z]) \d{2}-\d{2})|(CD \d{3}-\d{3})|(C-(C|X) \d{4})|(X-(A|B|C) \d{4})|(([EPVZ]-\d{5}))|(S A[A-Z]{2} \d{2})|(SP \d{2}-\d{2}))$/.test(str),
+  'ja-JP': str => /^[\u3041-\u3096\u4E00-\u9FFF]{1,4}[ -]?\d{2,3}[A-Z]?[ -]?(?![\u304A\u3057\u3078\u3090\u3091\u3093])[\u3042-\u3096][ -]?(\d{1,4}|\d{1,2}-\d{2})$/.test(str),
   'pt-BR': str =>
     /^[A-Z]{3}[ -]?[0-9][A-Z][0-9]{2}|[A-Z]{3}[ -]?[0-9]{4}$/.test(str),
   'pt-PT': str =>

--- a/test/validators.test.js
+++ b/test/validators.test.js
@@ -15047,6 +15047,26 @@ describe('Validators', () => {
     });
     test({
       validator: 'isLicensePlate',
+      args: ['ja-JP'],
+      valid: [
+        '\u54C1\u5DDD 300 \u3055 12-34',
+        '\u8DB3\u7ACB500\u304D21-41',
+        '\u306A\u306B\u308F 580 \u3042 1234',
+        '\u5C3E\u5F35\u5C0F\u7267 50A \u308C 1',
+      ],
+      invalid: [
+        '',
+        '\u54C1\u5DDD 300 \u3057 12-34',
+        '\u54C1\u5DDD 3 \u3055 12-34',
+        'TOKYO 300 \u3055 12-34',
+        '\u54C1\u5DDD 300 \u3055 123-4',
+        '\u54C1\u5DDD 300 \u3055 12345',
+        '\u54C1\u5DDD_300_\u3055_12-34',
+        '\u54C1\u5DDD 300 a 12-34',
+      ],
+    });
+    test({
+      validator: 'isLicensePlate',
       args: ['any'],
       valid: [
         'FL 1',


### PR DESCRIPTION
isLicensePlate: Added support for Japan (ja-JP), validating Japanese license plates (matching prefecture/class names in Kanji/Hiragana, class numbers, Hiragana indicator character, and a 1-to-4 digit sequence).
Documentation & Tests: Updated README.md to list ja-JP as a supported locale, and added unit tests in test/validators.test.js covering valid (e.g., 品川 300 さ 12-34) and invalid (e.g., TOKYO 300 さ 12-34) formats.