### PR TITLE
feat: add es-ES license plate validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Validator                               | Description
 **isJWT(str)**                          | check if the string is valid JWT token.
 **isLatLong(str [, options])**          | check if the string is a valid latitude-longitude coordinate in the format `lat,long` or `lat, long`.<br/><br/>`options` is an object that defaults to `{ checkDMS: false }`. Pass `checkDMS` as `true` to validate DMS(degrees, minutes, and seconds) latitude-longitude format.
 **isLength(str [, options])**           | check if the string's length falls in a range and equal to any of the integers of the `discreteLengths` array if provided.<br/><br/>`options` is an object which defaults to `{ min: 0, max: undefined, discreteLengths: undefined }`. Note: this function takes into account surrogate pairs.
-**isLicensePlate(str, locale)**         | check if the string matches the format of a country's license plate.<br/><br/>`locale` is one of `['cs-CZ', 'de-DE', 'de-LI', 'en-IN', 'en-SG', 'en-PK', 'es-AR', 'hu-HU', 'pt-BR', 'pt-PT', 'sq-AL', 'sv-SE']` or `'any'`.
+**isLicensePlate(str, locale)**         | check if the string matches the format of a country's license plate.<br/><br/>`locale` is one of `['cs-CZ', 'de-DE', 'de-LI', 'en-IN', 'en-SG', 'en-PK', 'es-AR', 'es-ES', 'hu-HU', 'pt-BR', 'pt-PT', 'sq-AL', 'sv-SE']` or `'any'`.
 **isLocale(str)**                       | check if the string is a locale.
 **isLowercase(str)**                    | check if the string is lowercase.
 **isLuhnNumber(str)**                    | check if the string passes the [Luhn algorithm check](https://en.wikipedia.org/wiki/Luhn_algorithm).

--- a/src/lib/isLicensePlate.js
+++ b/src/lib/isLicensePlate.js
@@ -9,6 +9,7 @@ const validators = {
   'en-IN': str => /^[A-Z]{2}[ -]?[0-9]{1,2}(?:[ -]?[A-Z])(?:[ -]?[A-Z]*)?[ -]?[0-9]{4}$/.test(str),
   'en-SG': str => /^[A-Z]{3}[ -]?[\d]{4}[ -]?[A-Z]{1}$/.test(str),
   'es-AR': str => /^(([A-Z]{2} ?[0-9]{3} ?[A-Z]{2})|([A-Z]{3} ?[0-9]{3}))$/.test(str),
+  'es-ES': str => /^\d{4}[ -]?[BCDFGHJKLMNPRSTVWXYZ]{3}$/.test(str),
   'fi-FI': str => /^(?=.{4,7})(([A-Z]{1,3}|[0-9]{1,3})[\s-]?([A-Z]{1,3}|[0-9]{1,5}))$/.test(str),
   'hu-HU': str => /^((((?!AAA)(([A-NPRSTVZWXY]{1})([A-PR-Z]{1})([A-HJ-NPR-Z]))|(A[ABC]I)|A[ABC]O|A[A-W]Q|BPI|BPO|UCO|UDO|XAO)-(?!000)\d{3})|(M\d{6})|((CK|DT|CD|HC|H[ABEFIKLMNPRSTVX]|MA|OT|R[A-Z]) \d{2}-\d{2})|(CD \d{3}-\d{3})|(C-(C|X) \d{4})|(X-(A|B|C) \d{4})|(([EPVZ]-\d{5}))|(S A[A-Z]{2} \d{2})|(SP \d{2}-\d{2}))$/.test(str),
   'pt-BR': str =>

--- a/test/validators.test.js
+++ b/test/validators.test.js
@@ -14773,6 +14773,26 @@ describe('Validators', () => {
     });
     test({
       validator: 'isLicensePlate',
+      args: ['es-ES'],
+      valid: [
+        '1234 BBB',
+        '1234BBB',
+        '0000 ZZZ',
+        '9876-HJK',
+      ],
+      invalid: [
+        '',
+        '123 ABC',
+        '12345 ABC',
+        '1234 ABCD',
+        '1234 AEI',
+        '1234 QQQ',
+        '1234 ABC',
+        'abcd bbb',
+      ],
+    });
+    test({
+      validator: 'isLicensePlate',
       args: ['pt-PT'],
       valid: [
         'AA-12-34',


### PR DESCRIPTION
short description of the changes for this issue:

isLicensePlate: Added support for Spain (es-ES), validating modern Spanish license plates (4 digits followed by 3 consonants, excluding vowels and Q).
Documentation & Tests: Updated README.md to list es-ES as a supported locale, and added unit tests in test/validators.test.js covering valid (e.g., 1234 BBB, 9876-HJK) and invalid (e.g., 1234 AEI, abcd bbb) formats.