### PR TITLE
feat: add fr-FR license plate validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Validator                               | Description
 **isJWT(str)**                          | check if the string is valid JWT token.
 **isLatLong(str [, options])**          | check if the string is a valid latitude-longitude coordinate in the format `lat,long` or `lat, long`.<br/><br/>`options` is an object that defaults to `{ checkDMS: false }`. Pass `checkDMS` as `true` to validate DMS(degrees, minutes, and seconds) latitude-longitude format.
 **isLength(str [, options])**           | check if the string's length falls in a range and equal to any of the integers of the `discreteLengths` array if provided.<br/><br/>`options` is an object which defaults to `{ min: 0, max: undefined, discreteLengths: undefined }`. Note: this function takes into account surrogate pairs.
-**isLicensePlate(str, locale)**         | check if the string matches the format of a country's license plate.<br/><br/>`locale` is one of `['cs-CZ', 'de-DE', 'de-LI', 'en-IN', 'en-SG', 'en-PK', 'es-AR', 'hu-HU', 'pt-BR', 'pt-PT', 'sq-AL', 'sv-SE']` or `'any'`.
+**isLicensePlate(str, locale)**         | check if the string matches the format of a country's license plate.<br/><br/>`locale` is one of `['cs-CZ', 'de-DE', 'de-LI', 'en-IN', 'en-SG', 'en-PK', 'es-AR', 'fr-FR', 'hu-HU', 'pt-BR', 'pt-PT', 'sq-AL', 'sv-SE']` or `'any'`.
 **isLocale(str)**                       | check if the string is a locale.
 **isLowercase(str)**                    | check if the string is lowercase.
 **isLuhnNumber(str)**                    | check if the string passes the [Luhn algorithm check](https://en.wikipedia.org/wiki/Luhn_algorithm).

--- a/src/lib/isLicensePlate.js
+++ b/src/lib/isLicensePlate.js
@@ -10,6 +10,7 @@ const validators = {
   'en-SG': str => /^[A-Z]{3}[ -]?[\d]{4}[ -]?[A-Z]{1}$/.test(str),
   'es-AR': str => /^(([A-Z]{2} ?[0-9]{3} ?[A-Z]{2})|([A-Z]{3} ?[0-9]{3}))$/.test(str),
   'fi-FI': str => /^(?=.{4,7})(([A-Z]{1,3}|[0-9]{1,3})[\s-]?([A-Z]{1,3}|[0-9]{1,5}))$/.test(str),
+  'fr-FR': str => /^[A-HJ-NP-TV-Z]{2}[- ]?\d{3}[- ]?[A-HJ-NP-TV-Z]{2}$/.test(str),
   'hu-HU': str => /^((((?!AAA)(([A-NPRSTVZWXY]{1})([A-PR-Z]{1})([A-HJ-NPR-Z]))|(A[ABC]I)|A[ABC]O|A[A-W]Q|BPI|BPO|UCO|UDO|XAO)-(?!000)\d{3})|(M\d{6})|((CK|DT|CD|HC|H[ABEFIKLMNPRSTVX]|MA|OT|R[A-Z]) \d{2}-\d{2})|(CD \d{3}-\d{3})|(C-(C|X) \d{4})|(X-(A|B|C) \d{4})|(([EPVZ]-\d{5}))|(S A[A-Z]{2} \d{2})|(SP \d{2}-\d{2}))$/.test(str),
   'pt-BR': str =>
     /^[A-Z]{3}[ -]?[0-9][A-Z][0-9]{2}|[A-Z]{3}[ -]?[0-9]{4}$/.test(str),

--- a/test/validators.test.js
+++ b/test/validators.test.js
@@ -14917,6 +14917,26 @@ describe('Validators', () => {
     });
     test({
       validator: 'isLicensePlate',
+      args: ['fr-FR'],
+      valid: [
+        'AB-123-CD',
+        'AB 123 CD',
+        'AB123CD',
+        'QZ-987-ZQ',
+      ],
+      invalid: [
+        '',
+        'AA-12-BB',
+        'AA-1234-BB',
+        'AI-123-BB',
+        'AO-123-BB',
+        'AU-123-BB',
+        'AB_123_CD',
+        'ab-123-cd',
+      ],
+    });
+    test({
+      validator: 'isLicensePlate',
       args: ['sq-AL'],
       valid: [
         'AA 000 AA',


### PR DESCRIPTION
 short description of the changes for this issue:

isLicensePlate: Added support for France (fr-FR), validating French SIV license plates (2 letters, 3 digits, 2 letters, excluding the characters I, O, and U to avoid optical confusion).
Documentation & Tests: Updated README.md to list fr-FR as a supported locale, and added unit tests in test/validators.test.js covering valid (e.g., AB-123-CD, AB123CD) and invalid (e.g., AI-123-BB, ab-123-cd) formats.