### PR TITLE
fix(isPassportNumber): support case-insensitive country codes

### DIFF
--- a/src/lib/isPassportNumber.js
+++ b/src/lib/isPassportNumber.js
@@ -83,7 +83,8 @@ export default function isPassportNumber(str, countryCode) {
   assertString(str);
   /** Remove All Whitespaces, Convert to UPPERCASE */
   const normalizedStr = str.replace(/\s/g, '').toUpperCase();
+  const normalizedCountryCode = countryCode.toUpperCase();
 
-  return (countryCode.toUpperCase() in passportRegexByCountryCode) &&
-    passportRegexByCountryCode[countryCode].test(normalizedStr);
+  return (normalizedCountryCode in passportRegexByCountryCode) &&
+    passportRegexByCountryCode[normalizedCountryCode].test(normalizedStr);
 }

--- a/test/validators.test.js
+++ b/test/validators.test.js
@@ -3243,6 +3243,28 @@ describe('Validators', () => {
       ],
     });
 
+    test({
+      validator: 'isPassportNumber',
+      args: ['am'],
+      valid: [
+        'AF0549358',
+      ],
+      invalid: [
+        'A1054935',
+      ],
+    });
+
+    test({
+      validator: 'isPassportNumber',
+      args: ['aM'],
+      valid: [
+        'AF0549358',
+      ],
+      invalid: [
+        'A1054935',
+      ],
+    });
+
 
     test({
       validator: 'isPassportNumber',


### PR DESCRIPTION
<!--
Add a descriptive title textbox above, e.g.
feat(validatorName): brief title of what has been done
-->

fix(isPassportNumber): support case-insensitive country codes

<!--- briefly describe what you have done in this PR --->

This PR fixes a `TypeError` in `isPassportNumber` when a lowercase or mixed-case country code is provided.

Previously, the validator checked the normalized uppercase country code but accessed the passport regex map using the original country code. The country code is now normalized once and used consistently for both operations.

Regression tests cover lowercase (`am`) and mixed-case (`aM`) country codes with valid and invalid Armenian passport numbers.

<!--- provide some (credible) references showing the structure of the data to be validated, if applicable --->

## Checklist

- [x] PR contains only changes related; no stray files, etc.
- [ ] README updated (where applicable)
- [x] Tests written (where applicable)
- [ ] References provided in PR (where applicable)
