### PR TITLE
fix(isByteLength): handle unpaired UTF-16 surrogates

### DIFF
--- a/src/lib/isByteLength.js
+++ b/src/lib/isByteLength.js
@@ -1,5 +1,29 @@
 import assertString from './util/assertString';
 
+function utf8ByteLength(str) {
+  let length = 0;
+
+  for (let i = 0; i < str.length; i++) {
+    const code = str.charCodeAt(i);
+
+    if (code <= 0x7F) {
+      length += 1;
+    } else if (code <= 0x7FF) {
+      length += 2;
+    } else if (code >= 0xD800 && code <= 0xDBFF &&
+      i + 1 < str.length &&
+      str.charCodeAt(i + 1) >= 0xDC00 && str.charCodeAt(i + 1) <= 0xDFFF) {
+      length += 4;
+      i += 1;
+    } else {
+      // UTF-8 encoders replace unpaired surrogates with U+FFFD (three bytes).
+      length += 3;
+    }
+  }
+
+  return length;
+}
+
 /* eslint-disable prefer-rest-params */
 export default function isByteLength(str, options) {
   assertString(str);
@@ -12,6 +36,6 @@ export default function isByteLength(str, options) {
     min = arguments[1];
     max = arguments[2];
   }
-  const len = encodeURI(str).split(/%..|./).length - 1;
+  const len = utf8ByteLength(str);
   return len >= min && (typeof max === 'undefined' || len <= max);
 }

--- a/test/validators.test.js
+++ b/test/validators.test.js
@@ -5757,6 +5757,34 @@ describe('Validators', () => {
     });
   });
 
+  it('should handle unpaired UTF-16 surrogates without throwing', () => {
+    test({
+      validator: 'isByteLength',
+      args: [{ min: 3, max: 3 }],
+      valid: ['\uD800', '\uDC00'],
+    });
+    test({
+      validator: 'isByteLength',
+      args: [{ max: 2 }],
+      invalid: ['\uD800', '\uDC00'],
+    });
+  });
+
+  it('should count UTF-16 surrogate pairs as four UTF-8 bytes', () => {
+    test({
+      validator: 'isByteLength',
+      args: [{ min: 4, max: 4 }],
+      valid: ['😀'],
+    });
+  });
+
+  it('should reject emails containing unpaired UTF-16 surrogates without throwing', () => {
+    test({
+      validator: 'isEmail',
+      invalid: ['\uD800@example.com', '\uDC00@example.com'],
+    });
+  });
+
   it('should validate ULIDs', () => {
     test({
       validator: 'isULID',


### PR DESCRIPTION
<!--
Add a descriptive title textbox above, e.g.
feat(validatorName): brief title of what has been done
-->

fix(isByteLength): handle unpaired UTF-16 surrogates

<!--- briefly describe what you have done in this PR --->

This PR fixes `isByteLength` throwing a `URIError` when passed a string containing an unpaired UTF-16 surrogate.

The previous implementation used `encodeURI` to calculate the UTF-8 byte length, but `encodeURI` rejects malformed surrogate sequences. The new implementation counts UTF-8 bytes directly and treats each unpaired surrogate as the three-byte replacement character (`U+FFFD`).

Regression tests verify that:

- Unpaired high and low surrogates are handled without throwing.
- Unpaired surrogates count as three UTF-8 bytes.
- Valid surrogate pairs count as four UTF-8 bytes.
- `isEmail`, which depends on `isByteLength`, rejects addresses containing unpaired surrogates without throwing.

<!--- provide some (credible) references showing the structure of the data to be validated, if applicable --->

References:

- [WHATWG Encoding Standard: handling UTF-16 surrogates in `TextEncoderStream`](https://encoding.spec.whatwg.org/#interface-textencoderstream)

## Checklist

- [x] PR contains only changes related; no stray files, etc.
- [ ] README updated (where applicable)
- [x] Tests written (where applicable)
- [x] References provided in PR (where applicable)
