### PR TITLE
ci: harden github actions and add a continuous check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,17 +13,17 @@ jobs:
     name: Run tests on Node.js ${{ matrix.node-version }}
     steps:
     - name: Setup Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version: ${{ matrix.node-version }}
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
     - name: Install dependencies
       run: npm install --legacy-peer-deps
     - name: Run tests
       run: npm test
     - if: matrix.node-version == 24
       name: Send coverage info to Codecov
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5.5.5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -38,11 +38,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@e60ea984bd3baa95954f2856bcf24f9eaba46637 # v3.37.5
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -53,7 +53,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v3
+      uses: github/codeql-action/autobuild@e60ea984bd3baa95954f2856bcf24f9eaba46637 # v3.37.5
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -67,4 +67,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@e60ea984bd3baa95954f2856bcf24f9eaba46637 # v3.37.5

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -10,12 +10,12 @@ jobs:
       id-token: write
     steps:
     - name: Setup Node.js 24
-      uses: actions/setup-node@v5
+      uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
       with:
         node-version: 24
         registry-url: https://registry.npmjs.org/
     - name: Checkout Repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
     - name: Install Dependencies
       run: npm install --legacy-peer-deps
     - name: Run Tests

--- a/.github/workflows/plumber.yml
+++ b/.github/workflows/plumber.yml
@@ -1,0 +1,34 @@
+name: Plumber
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  plumber:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      security-events: write
+      # Needed by score-push to publish the score for the README badge.
+      id-token: write
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+
+      - uses: getplumber/plumber@40bd6b5bb8ff4f0944feacaeb41dea6bce08d62d # v0.4.28
+        with:
+          # Code scanning upload needs security-events write, which PRs
+          # from forks do not get. The report stays available as a
+          # workflow artifact there.
+          upload-sarif: ${{ github.event.pull_request.head.repo.fork != true }}
+          # Publishes the score to score.getplumber.io, which feeds the
+          # badge in the README. A failed push never fails the run.
+          score-push: true
+          # Gate at 85 points instead of the all-or-nothing default,
+          # leaves room for a small finding without blocking PRs.
+          min-points: 85

--- a/.plumber.yaml
+++ b/.plumber.yaml
@@ -1,0 +1,15 @@
+# Plumber overlay: inherits every control from the CLI's built-in
+# baseline, only the differences for this repo are written here.
+# Run 'plumber config resolve' to see the full effective config.
+extends: plumber:default
+version: "2.0"
+
+github:
+  controls:
+    # The baseline also expects release/* branches to be protected;
+    # this repo's release branches are working branches. Keep the
+    # requirement on master, where the npm releases cut from.
+    branchMustBeProtected:
+      defaultMustBeProtected: true
+      namePatterns:
+        - master

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 [![NPM version][npm-image]][npm-url]
 [![CI][ci-image]][ci-url]
 [![Coverage][codecov-image]][codecov-url]
+[![Plumber Score][plumber-image]][plumber-url]
 [![Downloads][downloads-image]][npm-url]
 [![Backers on Open Collective](https://opencollective.com/validatorjs/backers/badge.svg)](#backers)
 [![Sponsors on Open Collective](https://opencollective.com/validatorjs/sponsors/badge.svg)](#sponsors)
@@ -229,6 +230,8 @@ This project is licensed under the [MIT](LICENSE). See the [LICENSE](LICENSE) fi
 
 [codecov-url]: https://codecov.io/gh/validatorjs/validator.js
 [codecov-image]: https://codecov.io/gh/validatorjs/validator.js/branch/master/graph/badge.svg
+[plumber-image]: https://score.getplumber.io/github.com/validatorjs/validator.js.svg
+[plumber-url]: https://score.getplumber.io/github.com/validatorjs/validator.js
 
 [ci-url]: https://github.com/validatorjs/validator.js/actions?query=workflow%3ACI
 [ci-image]: https://github.com/validatorjs/validator.js/workflows/CI/badge.svg?branch=master


### PR DESCRIPTION
Hi, drive-by CI hardening in three commits, one logical change each.

**Commit 1 pins every action to its commit sha**, versions kept as comments. A tag like `@v5` is a movable pointer: whoever controls the action, or anyone who compromises it, can re-point it and your next run executes their code with the job's token. This repo publishes to npm from CI, so the release path deserves frozen inputs. Same pattern as the tj-actions/changed-files incident (CVE-2025-30066). All shas were resolved from the upstream repos and cross checked against their release tags. The pins stay maintainable: a dependabot config with the `github-actions` ecosystem bumps them automatically, one small block.

**Commit 2 adds `permissions: contents: read` to the CI workflow**, the only one without a block. Coverage uploads use your dedicated CODECOV_TOKEN secret and the GitHub token is never used, so the scope is exact. The npm publish and CodeQL workflows already declare scoped permissions and are untouched.

**Commit 3 adds [Plumber](https://github.com/getplumber/plumber) to CI**, the tool I used to find the issues in the first place, so none of this quietly drifts back:

- Scans the workflows on each push to master and on each PR, fails when something regresses: an unpinned action, a job without permissions, a known CVE. The gate passes at 85 points, so one small finding does not block your PRs.
- The config is a 14 line overlay inheriting the CLI's built-in baseline, with one adjustment: the baseline also expects your `release/*` branches to be protected, the overlay keeps that requirement on master only, where the npm releases cut from. If you would rather protect the release branches instead, delete the overlay and the default applies.
- Adds a score badge to the README, reference-style like your existing ones. It works like OpenSSF Scorecard's published results: runs publish the score to score.getplumber.io, the badge shows the state of master, a failed publish never fails your CI, and it reads UNKNOWN in gray until the first run.

One heads up: if the org uses an Actions allowlist in settings, patterns written against tags (like `owner/action@v5`) stop matching once refs are shas and workflows refuse to start. Entries need to be `owner/action@*` in that case.

To be fully transparent: I work on Plumber. If you do not want the tool in your CI, no hard feelings, say so and I remove that commit from the PR, the two hardening commits are the part that matters and they stand entirely on their own.

## Checklist

- [X] PR contains only changes related; no stray files, etc.
- [X] README updated (where applicable)
- [X] Tests written (where applicable)
- [X] References provided in PR (where applicable)
