### PR TITLE
fix(index): export the real toString implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ Sanitizer                              | Description
 **toDate(input)**                      | convert the input string to a date, or `null` if the input is not a date.
 **toFloat(input)**                     | convert the input string to a float, or `NaN` if the input is not a float.
 **toInt(input [, radix])**             | convert the input string to an integer, or `NaN` if the input is not an integer.
+**toString(input)**                    | convert the input to a string. `null`, `undefined` and `NaN` are converted to an empty string, and objects are converted using their own `toString` method.
 **trim(input [, chars])**              | trim characters (whitespace by default) from both sides of the input.
 **unescape(input)**                    | replace HTML encoded entities with `<`, `>`, `&`, `'`, `"`, `` ` ``, `\` and `/`.
 **whitelist(input, chars)**            | remove characters that do not appear in the whitelist. The characters are used in a RegExp and so you will need to escape some chars, e.g. `whitelist(input, '\\[\\]')`.

--- a/src/index.js
+++ b/src/index.js
@@ -123,6 +123,7 @@ import blacklist from './lib/blacklist';
 import isWhitelisted from './lib/isWhitelisted';
 
 import normalizeEmail from './lib/normalizeEmail';
+import toString from './lib/util/toString';
 
 import isSlug from './lib/isSlug';
 import isLicensePlate from './lib/isLicensePlate';

--- a/test/exports.test.js
+++ b/test/exports.test.js
@@ -24,6 +24,14 @@ describe('Exports', () => {
     assert.strictEqual(typeof validator.toFloat, 'function');
   });
 
+  it('should export toString and not inherit Object.prototype.toString', () => {
+    assert.notStrictEqual(validator.toString, Object.prototype.toString);
+    assert.strictEqual(validator.toString('test'), 'test');
+    assert.strictEqual(validator.toString(123), '123');
+    assert.strictEqual(validator.toString(null), '');
+    assert.strictEqual(validator.toString(undefined), '');
+  });
+
   it('should export the version number', () => {
     /* eslint-disable global-require */
     assert.strictEqual(

--- a/test/sanitizers.test.js
+++ b/test/sanitizers.test.js
@@ -153,6 +153,18 @@ describe('Sanitizers', () => {
     });
   });
 
+  it('should convert inputs to strings', () => {
+    test({
+      sanitizer: 'toString',
+      expect: {
+        foo: 'foo',
+        '': '',
+        123: '123',
+        ' bar ': ' bar ',
+      },
+    });
+  });
+
   it('should escape HTML', () => {
     test({
       sanitizer: 'escape',


### PR DESCRIPTION
Fixes #1870.

`toString` is listed in the exported object in `src/index.js`, but the file never imports it. So the shorthand property just picks up the inherited `Object.prototype.toString`, and the real implementation in `src/lib/util/toString.js` is never exposed:

```js
const validator = require('validator');

validator.toString('test');                        // '[object Object]'
validator.toString === Object.prototype.toString;  // true
```

The other `to*` sanitizers (`toDate`, `toFloat`, `toInt`, `toBoolean`) are each imported at the top of `index.js`, exported, and documented in the README. `toString` was the only one missing its import, and it sits in the export list right between `normalizeEmail` and `isSlug`, which is exactly where the import would have gone. So this looks like an import that got dropped rather than an intentional omission.

Adding the import makes it behave like the util it points at:

```js
validator.toString('test');  // 'test'
validator.toString(123);     // '123'
validator.toString(null);    // ''
```

I went with wiring up the import rather than deleting the export, since that's what the one commenter on the issue asked for, and removing it wouldn't really change anything for callers (`validator.toString` would still resolve through the prototype). Happy to flip it to a removal if you'd rather shrink the API surface.

Worth noting the existing `should export sanitizers` test only does a `typeof` check, which can't catch this since `typeof validator.toString` was already `'function'`. The new test in `exports.test.js` asserts it isn't the prototype method, so it fails on master and passes here.

Full suite is 292 passing, eslint clean.

## Checklist

- [x] PR contains only changes related; no stray files, etc.
- [x] README updated (where applicable)
- [x] Tests written (where applicable)
- [x] References provided in PR (where applicable)
