### PR TITLE
fix(isISO4217): add missing active currency codes ZWG and XCG

### DIFF
--- a/src/lib/isISO4217.js
+++ b/src/lib/isISO4217.js
@@ -25,9 +25,9 @@ const validISO4217CurrencyCodes = new Set([
   'UAH', 'UGX', 'USD', 'USN', 'UYI', 'UYU', 'UYW', 'UZS',
   'VED', 'VES', 'VND', 'VUV',
   'WST',
-  'XAF', 'XAG', 'XAU', 'XBA', 'XBB', 'XBC', 'XBD', 'XCD', 'XDR', 'XOF', 'XPD', 'XPF', 'XPT', 'XSU', 'XTS', 'XUA', 'XXX',
+  'XAF', 'XAG', 'XAU', 'XBA', 'XBB', 'XBC', 'XBD', 'XCD', 'XCG', 'XDR', 'XOF', 'XPD', 'XPF', 'XPT', 'XSU', 'XTS', 'XUA', 'XXX',
   'YER',
-  'ZAR', 'ZMW', 'ZWL',
+  'ZAR', 'ZMW', 'ZWG', 'ZWL',
 ]);
 
 export default function isISO4217(str) {

--- a/test/validators.test.js
+++ b/test/validators.test.js
@@ -12668,6 +12668,8 @@ describe('Validators', () => {
         'USD',
         'VED',
         'SLE',
+        'XCG',
+        'ZWG',
       ],
       invalid: [
         '',


### PR DESCRIPTION
`isISO4217` is missing two currency codes that are currently active in ISO 4217, so both are rejected today:

```js
validator.isISO4217('ZWG'); // false, should be true
validator.isISO4217('XCG'); // false, should be true
```

| Code | Currency | Added |
|---|---|---|
| `ZWG` | Zimbabwe Gold (ZiG) | ISO 4217 amendment 177, 2024. Replaced ZWL as Zimbabwe's currency |
| `XCG` | Caribbean guilder | Amendment 176. Entered circulation 2025-03-31 for Curaçao and Sint Maarten, replacing ANG |

The list is otherwise current through the 2018-2022 amendments (`MRU`, `STN`, `UYW`, `VED`, `VES`, `SLE` are all present), so it just hasn't caught up with the two most recent ones.

### How I found it

Diffed the code list against the ISO 4217 amendment history rather than reading it, checking each recent amendment in turn. That's also how I confirmed nothing else is missing: `SLE`, `VED`, `UYW`, `STN`, `MRU` are all already there.

References:
- https://www.six-group.com/en/products-services/financial-information/data-standards.html (ISO 4217 maintenance agency, amendment list)
- https://en.wikipedia.org/wiki/ISO_4217 — the source the file already cites

### Scope

Purely additive, both inserted alphabetically. Verified the existing entries still behave, including the lowercase path (`isISO4217` upper-cases before lookup, so `'zwg'` works too).

I deliberately did **not** touch the withdrawn codes. `ZWL` and `SLL` are still accepted even though they've been superseded, while `VEF`, `STD` and `MRO` were removed at some point, so the list is inconsistent about historical codes. Removing `ZWL`/`SLL` would be a breaking change for anyone validating historical records, so that seems like your call rather than something to slip into this PR. Happy to follow up if you want them gone.

Full suite 290 passing, eslint clean.

## Checklist

- [x] PR contains only changes related; no stray files, etc.
- [x] README updated (where applicable) — the README doesn't enumerate currency codes, so nothing to change
- [x] Tests written (where applicable)
- [x] References provided in PR (where applicable)
