### PR TITLE
fix(isISO8601): validate week dates in strict mode

### DIFF
--- a/src/lib/isISO8601.js
+++ b/src/lib/isISO8601.js
@@ -6,6 +6,20 @@ const iso8601 = /^([\+-]?\d{4}(?!\d{2}\b))((-?)((0[1-9]|1[0-2])(\3([12]\d|0[1-9]
 // same as above, except with a strict 'T' separator between date and time
 const iso8601StrictSeparator = /^([\+-]?\d{4}(?!\d{2}\b))((-?)((0[1-9]|1[0-2])(\3([12]\d|0[1-9]|3[01]))?|W(0[1-9]|[1-4]\d|5[0-3])(-?[1-7])?|(00[1-9]|0[1-9]\d|[12]\d{2}|3([0-5]\d|6[0-6])))([T]((([01]\d|2[0-3])((:?)[0-5]\d)?|24:?00)([\.,]\d+(?!:))?)?(\17[0-5]\d([\.,]\d+)?)?([zZ]|([\+-])([01]\d|2[0-3]):?([0-5]\d)?)?)?)?$/;
 /* eslint-enable max-len */
+// Returns true iff ISO week-numbering year `year` has a 53rd week, i.e. 31
+// December of that year falls within ISO week 53 rather than week 1 of the
+// following year. Only week 53 is year-dependent -- weeks 01-52 always exist
+// -- and the main iso8601 regex already constrains the week field to 01-53
+// syntactically, so this is the only additional check strict mode needs.
+const hasISOWeek53 = (year) => {
+  const dec31 = new Date(Date.UTC(year, 11, 31));
+  const dayNum = dec31.getUTCDay() || 7; // Sunday (0) -> 7, so Mon=1..Sun=7
+  dec31.setUTCDate(dec31.getUTCDate() + (4 - dayNum)); // Thursday of the same ISO week
+  const yearStart = new Date(Date.UTC(dec31.getUTCFullYear(), 0, 1));
+  const week = Math.ceil((((dec31 - yearStart) / 86400000) + 1) / 7);
+  return week === 53;
+};
+
 const isValidDate = (str) => {
   // str must have passed the ISO8601 check
   // this check is meant to catch invalid dates
@@ -18,6 +32,13 @@ const isValidDate = (str) => {
     // if is leap year
     if ((oYear % 4 === 0 && oYear % 100 !== 0) || oYear % 400 === 0) return oDay <= 366;
     return oDay <= 365;
+  }
+  // then check for week dates (YYYY-Www or YYYY-Www-D, basic or extended)
+  const weekMatch = str.match(/^([\+-]?\d{4})-?W(\d{2})/);
+  if (weekMatch) {
+    const wYear = Number(weekMatch[1]);
+    const week = Number(weekMatch[2]);
+    return week <= 52 || hasISOWeek53(wYear);
   }
   const match = str.match(/(\d{4})-?(\d{0,2})-?(\d*)/).map(Number);
   const year = match[1];

--- a/test/validators.test.js
+++ b/test/validators.test.js
@@ -12448,6 +12448,9 @@ describe('Validators', () => {
         '2015-W53',
         '2020-W53-7',
         '2026-W53',
+        // weeks 01-52 exist in every ISO week-numbering year, long or short
+        '2020-W10',
+        '2020-W10-3',
       ],
       invalid: [
         '2010-02-30',
@@ -12461,6 +12464,9 @@ describe('Validators', () => {
         '2019-W53',
         '2021-W53-7',
         '2022-W53',
+        // 31 December 2017 is a Sunday, so the ISO remap of getUTCDay() 0 -> 7
+        // runs here; 2017 is still a short year, so week 53 does not exist.
+        '2017-W53',
       ],
     });
   });

--- a/test/validators.test.js
+++ b/test/validators.test.js
@@ -12443,12 +12443,24 @@ describe('Validators', () => {
         '2009-222',
         '2020-366',
         '2400-366',
+        // week 53 exists in these ISO week-numbering years (long years)
+        '2015-W53-1',
+        '2015-W53',
+        '2020-W53-7',
+        '2026-W53',
       ],
       invalid: [
         '2010-02-30',
         '2009-02-29',
         '2009-366',
         '2019-02-31',
+        // week 53 does not exist in these ISO week-numbering years (short
+        // years) -- regression test for #2859: previously strict mode never
+        // validated week dates at all, so these were wrongly accepted.
+        '2019-W53-1',
+        '2019-W53',
+        '2021-W53-7',
+        '2022-W53',
       ],
     });
   });


### PR DESCRIPTION
## What

`isISO8601(str, { strict: true })` never actually validates week dates (`YYYY-Www` / `YYYY-Www-D`). `isValidDate()` has no branch for them, so a week-date string falls through to the ordinal/calendar-date branch:

```js
const match = str.match(/(\d{4})-?(\d{0,2})-?(\d*)/).map(Number);
```

Against `"2019-W53"`, this loose regex only captures the year (`"W53"` isn't digits, so `month`/`day` capture empty strings → `NaN` after `Number()`). With `month`/`day` falsy, the function skips the date-object comparison entirely and returns `true` unconditionally:

```js
if (month && day) { ... }
return true;
```

So every syntactically-valid week-date string passes strict mode regardless of whether the year actually has that many weeks. The main `iso8601` regex already constrains the week field to `01`-`53` syntactically, but only weeks 01-52 exist in *every* ISO week-numbering year — week 53 exists only in "long" years (years whose 31 December falls in week 53 rather than week 1 of the next year). `2019-W53-1`, for example, is not a real date, but strict mode accepts it today.

## Fix

Added `hasISOWeek53(year)`, using the standard ISO week-number algorithm (move 31 December to the Thursday of its own ISO week, then compare that Thursday's year-relative week number), and a `weekMatch` branch in `isValidDate` that applies it:

```js
const weekMatch = str.match(/^([\+-]?\d{4})-?W(\d{2})/);
if (weekMatch) {
  const wYear = Number(weekMatch[1]);
  const week = Number(weekMatch[2]);
  return week <= 52 || hasISOWeek53(wYear);
}
```

## Testing

- Added 8 cases to the existing `'should validate ISO 8601 dates, with strict = true'` test block: 4 valid (`2015-W53-1`, `2015-W53`, `2020-W53-7`, `2026-W53` — all real long years) and 4 invalid (`2019-W53-1`, `2019-W53`, `2021-W53-7`, `2022-W53` — all real short years, so week 53 doesn't exist).
- Verified the week-53 algorithm standalone against known long/short ISO week-numbering years before wiring it in.
- **Negative control**: reverted just the `isISO8601.js` fix (kept the new tests) and reran — the `strict = true` block fails exactly as expected, on the first new invalid case (`isISO8601("2019-W53-1", {strict:true})` passed but should have failed). Restored the fix and reran clean.
- Full suite after restoring the fix: `npm run build && npm run lint && mocha` — **292/292 passing**, lint clean.

Fixes #2859.

Related-but-separate issues in the same cluster (not addressed by this PR):
- #2860, #2861 already have open PRs (#2865, #2864 respectively).
- #2858 (T24:00 separator capture-group issue) needs capture-group renumbering across a regex shared with `iso8601StrictSeparator` — left alone as too risky to fix without dedicated attention.
- #2862, #2863 not investigated as part of this PR.
