### PR TITLE
fix(isISO6346): anchor the pattern and reject a literal comma

### DIFF
--- a/src/lib/isISO6346.js
+++ b/src/lib/isISO6346.js
@@ -3,7 +3,7 @@ import assertString from './util/assertString';
 // https://en.wikipedia.org/wiki/ISO_6346
 // according to ISO6346 standard, checksum digit is mandatory for freight container but recommended
 // for other container types (J and Z)
-const isISO6346Str = /^[A-Z]{3}(U[0-9]{7})|([J,Z][0-9]{6,7})$/;
+const isISO6346Str = /^[A-Z]{3}(?:U[0-9]{7}|[JZ][0-9]{6,7})$/;
 const isDigit = /^[0-9]$/;
 
 export function isISO6346(str) {

--- a/test/validators.test.js
+++ b/test/validators.test.js
@@ -13615,6 +13615,9 @@ describe('Validators', () => {
         'ECMJ4657496',
         'TBJA7176445',
         'AFFU5962593',
+        'HLXU2008419HELLO',
+        'HELLOHLXU2008419',
+        'QJR,123456',
       ],
     });
   });


### PR DESCRIPTION
Closes #2772.

### Bug

`isISO6346` (and its alias `isFreightContainerID`) accepts malformed strings because its regex has two flaws:

```js
const isISO6346Str = /^[A-Z]{3}(U[0-9]{7})|([J,Z][0-9]{6,7})$/;
```

1. **Unanchored alternation.** The `|` splits the whole pattern, so `^` anchors only the first branch and `$` only the second. Anything *starting* with `[A-Z]{3}U` + 7 digits matches regardless of trailing junk, and anything *ending* with `[JZ]` + 6-7 digits matches regardless of leading junk.
2. **Literal comma in the class.** `[J,Z]` matches `J`, `Z`, **or `,`**.

Inputs whose length isn't 11 skip the checksum and return `true`, so malformed strings pass:

```js
isISO6346('HLXU2008419HELLO'); // true  ❌ (trailing junk)
isISO6346('QJR,123456');       // true  ❌ (literal comma)
```

### Fix

Group the alternation under the shared `^[A-Z]{3}` prefix and end anchor, and drop the stray comma:

```js
const isISO6346Str = /^[A-Z]{3}(?:U[0-9]{7}|[JZ][0-9]{6,7})$/;
```

### Tests

Added trailing-junk, leading-junk, and literal-comma cases to the invalid list. Verified against the full existing suite: all 10 valid IDs (incl. the `QJRZ123456` J/Z 6-digit case) stay valid and all invalid IDs (incl. the 3 new ones) are rejected.
