### PR TITLE
fix(isFloat): fall back to '.' separator for an unknown locale

### DIFF
--- a/src/lib/isFloat.js
+++ b/src/lib/isFloat.js
@@ -5,9 +5,13 @@ import { decimal } from './alpha';
 export default function isFloat(str, options) {
   assertString(str);
   options = options || {};
-  // Fall back to `.` when the locale is unknown; otherwise `decimal[locale]`
-  // is `undefined` and stringifies into the pattern as the literal `undefined`.
-  const decimalSeparator = decimal[options.locale] || '.';
+  // Fall back to `.` unless the locale is an own key of `decimal`. Indexing
+  // `decimal[options.locale]` directly would also match inherited names such as
+  // `__proto__`, `constructor` or `toString`, whose truthy values leak into the
+  // pattern (e.g. the separator becomes the literal `[object Object]`).
+  const decimalSeparator = Object.prototype.hasOwnProperty.call(decimal, options.locale)
+    ? decimal[options.locale]
+    : '.';
   const float = new RegExp(`^(?:[-+])?(?:[0-9]+)?(?:\\${decimalSeparator}[0-9]*)?(?:[eE][\\+\\-]?(?:[0-9]+))?$`);
   if (str === '' || str === '.' || str === ',' || str === '-' || str === '+') {
     return false;

--- a/src/lib/isFloat.js
+++ b/src/lib/isFloat.js
@@ -5,7 +5,10 @@ import { decimal } from './alpha';
 export default function isFloat(str, options) {
   assertString(str);
   options = options || {};
-  const float = new RegExp(`^(?:[-+])?(?:[0-9]+)?(?:\\${options.locale ? decimal[options.locale] : '.'}[0-9]*)?(?:[eE][\\+\\-]?(?:[0-9]+))?$`);
+  // Fall back to `.` when the locale is unknown; otherwise `decimal[locale]`
+  // is `undefined` and stringifies into the pattern as the literal `undefined`.
+  const decimalSeparator = decimal[options.locale] || '.';
+  const float = new RegExp(`^(?:[-+])?(?:[0-9]+)?(?:\\${decimalSeparator}[0-9]*)?(?:[eE][\\+\\-]?(?:[0-9]+))?$`);
   if (str === '' || str === '.' || str === ',' || str === '-' || str === '+') {
     return false;
   }

--- a/test/validators.test.js
+++ b/test/validators.test.js
@@ -4860,6 +4860,23 @@ describe('Validators', () => {
     test({
       validator: 'isFloat',
       args: [{
+        locale: 'is-NOT-a-locale',
+      }],
+      valid: [
+        '123',
+        '123.123',
+        '-3.5e2',
+      ],
+      invalid: [
+        '3undefined5',
+        '123,123',
+        'foo',
+        '',
+      ],
+    });
+    test({
+      validator: 'isFloat',
+      args: [{
         min: undefined,
         max: undefined,
       }],

--- a/test/validators.test.js
+++ b/test/validators.test.js
@@ -4874,6 +4874,25 @@ describe('Validators', () => {
         '',
       ],
     });
+    // Inherited property names (e.g. __proto__, constructor) are not own keys of
+    // the decimal map, so they must fall back to the "." separator too.
+    for (const inheritedLocale of ['__proto__', 'constructor', 'toString', 'hasOwnProperty', 'valueOf']) {
+      test({
+        validator: 'isFloat',
+        args: [{ locale: inheritedLocale }],
+        valid: [
+          '123',
+          '123.123',
+          '-3.5e2',
+        ],
+        invalid: [
+          '123,123',
+          '3[object Object]5',
+          'foo',
+          '',
+        ],
+      });
+    }
     test({
       validator: 'isFloat',
       args: [{


### PR DESCRIPTION
Closes #2862.

### Bug

`isFloat` interpolates the locale separator straight into a new `RegExp`:

```js
const float = new RegExp(`^(?:[-+])?(?:[0-9]+)?(?:\${options.locale ? decimal[options.locale] : '.'}[0-9]*)?...`);
```

When `options.locale` is not a key of `decimal`, `decimal[options.locale]` is `undefined`, which stringifies into the pattern as the literal text `undefined`. The preceding `\` yields `\undefined`, and since `\u` isn't followed by four hex digits it degrades to a literal `u`, so the "decimal separator" becomes the 8-character string `undefined`. There's no error and no fallback:

```js
isFloat('3undefined5', { locale: 'no-such' }); // true  ❌
isFloat('3.5',         { locale: 'no-such' }); // false ❌
```

### Fix

Fall back to `.` when the locale is unknown:

```js
const decimalSeparator = decimal[options.locale] || '.';
```

Known locales are unaffected (their separator is always `.` or `,`, both truthy), and the no-locale path already resolved to `.`.

### Tests

Added an unknown-locale block asserting ordinary decimals validate and the `undefined`-separator strings no longer pass. Verified known-locale behavior (en-US `.`, de-DE `,`) is unchanged.
