### PR TITLE
fix(isLatLong): reject extra coordinate components

### DIFF
--- a/src/lib/isLatLong.js
+++ b/src/lib/isLatLong.js
@@ -1,6 +1,5 @@
 import assertString from './util/assertString';
 import merge from './util/merge';
-import includes from './util/includesString';
 
 const lat = /^\(?[+-]?(90(\.0+)?|[1-8]?\d(\.\d+)?)$/;
 const long = /^\s?[+-]?(180(\.0+)?|1[0-7]\d(\.\d+)?|\d{1,2}(\.\d+)?)\)?$/;
@@ -16,8 +15,8 @@ export default function isLatLong(str, options) {
   assertString(str);
   options = merge(options, defaultLatLongOptions);
 
-  if (!includes(str, ',')) return false;
   const pair = str.split(',');
+  if (pair.length !== 2) return false;
   if ((pair[0].startsWith('(') && !pair[1].endsWith(')'))
     || (pair[1].endsWith(')') && !pair[0].startsWith('('))) return false;
 

--- a/test/validators.test.js
+++ b/test/validators.test.js
@@ -12856,6 +12856,33 @@ describe('Validators', () => {
     });
   });
 
+  it('should reject extra decimal LatLong components', () => {
+    test({
+      validator: 'isLatLong',
+      invalid: [
+        '0,0,',
+        '0,0,0',
+        '0,0,garbage',
+        '0, 0, 0, 0',
+        '(0, 0),',
+        '(0, 0),garbage',
+      ],
+    });
+  });
+
+  it('should reject extra DMS LatLong components', () => {
+    test({
+      validator: 'isLatLong',
+      args: [{ checkDMS: true }],
+      invalid: [
+        '40° 26′ 46″ N, 79° 58′ 56″ W,',
+        '40° 26′ 46″ N, 79° 58′ 56″ W,0',
+        '40° 26′ 46″ N, 79° 58′ 56″ W,garbage',
+        '40° 26′ 46″ N, 79° 58′ 56″ W,0,0',
+      ],
+    });
+  });
+
   it('should validate postal code', () => {
     const fixtures = [
       {


### PR DESCRIPTION
`isLatLong` splits the input on commas but validates only the first two components, so `isLatLong('0,0,garbage')` and a valid DMS pair followed by `,garbage` return `true`.

Require exactly two components before validating them. This rejects trailing commas and additional numeric or text fields in both decimal and DMS modes, matching the documented `lat,long` / `lat, long` format. Existing coordinate ranges, parentheses and formatting checks remain unchanged.

Reference: [documented isLatLong format](https://github.com/validatorjs/validator.js/blob/master/README.md#validators). I checked related open and closed PRs; #1074 handles parentheses and #1340 adds DMS support, but neither checks for extra components. The open test reorganization in #2698 does not fix this behavior.

Validation on Node.js 24.19.0:

- Added two regression tests covering 10 malformed inputs; both tests fail against unchanged master.
- `npm test` passes: 325 tests, including build and lint.
- 88 additional assertions pass across source, Node, browser and minified browser builds.
- `git diff --check` passes.

This change was prepared and independently reviewed with Codex; the checks above were run locally.

## Checklist

- [x] PR contains only related changes
- [x] README reviewed; existing documented pair format already describes the intended behavior
- [x] Regression tests added
- [x] References provided
