### PR TITLE
fix(isMimeType): allow underscores in parameterized MIME types

### DIFF
--- a/src/lib/isMimeType.js
+++ b/src/lib/isMimeType.js
@@ -29,10 +29,10 @@ import assertString from './util/assertString';
 const mimeTypeSimple = /^(application|audio|font|image|message|model|multipart|text|video)\/[a-zA-Z0-9\.\-\+_]{1,100}$/i; // eslint-disable-line max-len
 
 // Handle "charset" in "text/*"
-const mimeTypeText = /^text\/[a-zA-Z0-9\.\-\+]{1,100};\s?charset=("[a-zA-Z0-9\.\-\+\s]{0,70}"|[a-zA-Z0-9\.\-\+]{0,70})(\s?\([a-zA-Z0-9\.\-\+\s]{1,20}\))?$/i; // eslint-disable-line max-len
+const mimeTypeText = /^text\/[a-zA-Z0-9\.\-\+_]{1,100};\s?charset=("[a-zA-Z0-9\.\-\+_\s]{0,70}"|[a-zA-Z0-9\.\-\+_]{0,70})(\s?\([a-zA-Z0-9\.\-\+\s]{1,20}\))?$/i; // eslint-disable-line max-len
 
 // Handle "boundary" in "multipart/*"
-const mimeTypeMultipart = /^multipart\/[a-zA-Z0-9\.\-\+]{1,100}(;\s?(boundary|charset)=("[a-zA-Z0-9\.\-\+\s]{0,70}"|[a-zA-Z0-9\.\-\+]{0,70})(\s?\([a-zA-Z0-9\.\-\+\s]{1,20}\))?){0,2}$/i; // eslint-disable-line max-len
+const mimeTypeMultipart = /^multipart\/[a-zA-Z0-9\.\-\+_]{1,100}(;\s?(boundary|charset)=("[a-zA-Z0-9\.\-\+_\s]{0,70}"|[a-zA-Z0-9\.\-\+_]{0,70})(\s?\([a-zA-Z0-9\.\-\+\s]{1,20}\))?){0,2}$/i; // eslint-disable-line max-len
 
 export default function isMimeType(str) {
   assertString(str);

--- a/test/validators.test.js
+++ b/test/validators.test.js
@@ -13544,6 +13544,39 @@ describe('Validators', () => {
     });
   });
 
+  it('should validate underscores in text MIME subtypes and charsets', () => {
+    test({
+      validator: 'isMimeType',
+      valid: [
+        'text/x_custom; charset=utf-8',
+        'text/plain; charset=ANSI_X3.4-1968',
+        'text/plain; charset="ISO_8859-1"',
+        'text/x_custom; charset="ISO_8859-1"',
+      ],
+      invalid: [
+        'text/x custom; charset=utf-8',
+        'text/plain; charset=ISO_8859 1',
+      ],
+    });
+  });
+
+  it('should validate underscores in multipart MIME subtypes and parameters', () => {
+    test({
+      validator: 'isMimeType',
+      valid: [
+        'multipart/x_custom; boundary=part',
+        'multipart/form-data; boundary=----Part_123',
+        'multipart/form-data; boundary="----Part_123"',
+        'multipart/mixed; charset=ISO_8859-1; boundary=part',
+        'multipart/mixed; boundary=part; charset="ISO_8859-1"',
+      ],
+      invalid: [
+        'multipart/form-data; boundary=----Part_123 other',
+        'multipart/form-data; boundary="----Part_123',
+      ],
+    });
+  });
+
   it('should validate MIME types', () => {
     test({
       validator: 'isMimeType',


### PR DESCRIPTION
`isMimeType('text/plain; charset=ANSI_X3.4-1968')` and `isMimeType('multipart/form-data; boundary=----Part_123')` currently return false. Underscores are valid in these values: the charset is an IANA alias, and RFC 2046 explicitly includes `_` in multipart boundary characters.

Add `_` to the text/multipart subtype and quoted/unquoted parameter value character classes. This also makes parameterized subtype handling consistent with the simple MIME pattern, which already accepts underscores.

This extends the cases covered by merged PR #2120: its actual change only updated the simple MIME pattern. I checked related open/closed MIME, charset and boundary PRs and found no matching implementation.

Validation:

- All nine new valid inputs returned false before the fix; both added regression tests failed.
- `npm test`: 325 passing, including Node/ES/browser builds and ESLint.
- Node, browser and minified-browser distributions: 12 additional assertions passed.
- `git diff --check`: passed.

References: [RFC 2046 section 5.1.1](https://www.rfc-editor.org/rfc/rfc2046.html#section-5.1.1), [RFC 6838 section 4.2](https://www.rfc-editor.org/rfc/rfc6838.html#section-4.2), [IANA character sets](https://www.iana.org/assignments/character-sets/character-sets.xhtml).

## Checklist

- [x] PR contains only related changes.
- [x] Tests written.
- [x] References provided.
- README update is not applicable: the documented MIME-format contract is unchanged.